### PR TITLE
fix(build): build.ps1 CMake 缓存路径不匹配问题

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,9 @@ charset=utf-8-bom
 # C/C++ code formatting
 [*.{c,h}]
 cpp_space_pointer_reference_alignment = right
+
+# PowerShell scripts should keep UTF-8 BOM for Windows PowerShell 5.1 compatibility.
+[*.ps1]
+charset = utf-8-bom
+end_of_line = crlf
+insert_final_newline = true

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-# ============================================================
+﻿# ============================================================
 #  Antigravity-Proxy 编译脚本
 #  PowerShell Build Script for Windows
 # ============================================================
@@ -183,9 +183,13 @@ try {
 
     # 处理项目目录迁移后的旧缓存：自动清理并重试一次
     if ($cmakeFailed) {
-        $cmakeText = ($cmakeResult | Out-String)
-        $isCacheMismatch = $cmakeText -match "CMakeCache\.txt directory .* is different than the directory" -or
-                          $cmakeText -match "does not match the source .* used to generate cache"
+        # 兼容 Windows PowerShell 5.1:
+        # - 2>&1 可能返回 ErrorRecord 而非纯字符串
+        # - 输出可能按控制台宽度换行，导致关键句子被拆断
+        $cmakeText = (($cmakeResult | ForEach-Object { $_.ToString() }) -join "`n")
+        $cmakeTextNormalized = [regex]::Replace($cmakeText, "\s+", " ")
+        $isCacheMismatch = $cmakeTextNormalized -match "CMakeCache\.txt directory .* is different than the directory" -or
+                          $cmakeTextNormalized -match "does not match the source .* used to generate cache"
 
         if ($isCacheMismatch) {
             Pop-Location


### PR DESCRIPTION
>解决了 CMake 缓存路径不匹配问题，
修复前的脚本不会根据不同用户的cmake目录自动调整导致无法构建

- 在配置阶段检测 CMake 缓存/源码路径，若不匹配，清理后重试一次
- 解决仓库迁移到新绝对路径后构建直接失败的问题