### PR TITLE
fix(injection): report accurate child-process injection outcomes

### DIFF
--- a/src/hooks/Hooks.cpp
+++ b/src/hooks/Hooks.cpp
@@ -2961,11 +2961,13 @@ BOOL WINAPI DetourCreateProcessW(
             // 注入 DLL 到子进程
             std::wstring dllPath = Injection::ProcessInjector::GetCurrentDllPath();
             if (!dllPath.empty()) {
-                const bool injected = Injection::ProcessInjector::InjectDll(lpProcessInformation->hProcess, dllPath);
+                std::string injectFailureReason;
+                const bool injected = Injection::ProcessInjector::InjectDll(lpProcessInformation->hProcess, dllPath, &injectFailureReason);
                 if (injected) {
                     Core::Logger::Info("[成功] 已注入目标进程: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ") - 父子关系建立");
                 } else {
-                    Core::Logger::Error("[失败] 注入目标进程失败: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")");
+                    Core::Logger::Error("[失败] 注入目标进程失败: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")" +
+                                       (injectFailureReason.empty() ? std::string("") : (", 原因: " + injectFailureReason)));
                 }
             } else {
                 Core::Logger::Error("[失败] 获取当前 DLL 路径失败，跳过注入: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")");
@@ -3069,11 +3071,13 @@ BOOL WINAPI DetourCreateProcessA(
             // 注入 DLL 到子进程
             std::wstring dllPath = Injection::ProcessInjector::GetCurrentDllPath();
             if (!dllPath.empty()) {
-                const bool injected = Injection::ProcessInjector::InjectDll(lpProcessInformation->hProcess, dllPath);
+                std::string injectFailureReason;
+                const bool injected = Injection::ProcessInjector::InjectDll(lpProcessInformation->hProcess, dllPath, &injectFailureReason);
                 if (injected) {
                     Core::Logger::Info("[成功] 已注入目标进程: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ") - 父子关系建立");
                 } else {
-                    Core::Logger::Error("[失败] 注入目标进程失败: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")");
+                    Core::Logger::Error("[失败] 注入目标进程失败: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")" +
+                                       (injectFailureReason.empty() ? std::string("") : (", 原因: " + injectFailureReason)));
                 }
             } else {
                 Core::Logger::Error("[失败] 获取当前 DLL 路径失败，跳过注入: " + appName + " (PID: " + std::to_string(lpProcessInformation->dwProcessId) + ")");

--- a/src/injection/ProcessInjector.hpp
+++ b/src/injection/ProcessInjector.hpp
@@ -18,8 +18,15 @@ namespace Injection {
         // 注入 DLL 到目标进程
         // hProcess: 目标进程句柄 (需要 PROCESS_ALL_ACCESS 权限)
         // dllPath: 要注入的 DLL 完整路径
+        // failureReason: 可选，失败时返回简短诊断信息
         // 返回: 成功返回 true
-        static bool InjectDll(HANDLE hProcess, const std::wstring& dllPath) {
+        static bool InjectDll(HANDLE hProcess, const std::wstring& dllPath, std::string* failureReason = nullptr) {
+            const auto setFailureReason = [failureReason](const std::string& reason) {
+                if (failureReason) {
+                    *failureReason = reason;
+                }
+            };
+
             // 步骤 1: 在目标进程中分配内存
             SIZE_T dllPathSize = (dllPath.length() + 1) * sizeof(wchar_t);
             LPVOID remoteDllPath = VirtualAllocEx(
@@ -31,13 +38,17 @@ namespace Injection {
             );
             
             if (!remoteDllPath) {
-                Core::Logger::Error("ProcessInjector: 虚拟内存分配失败 (VirtualAllocEx failed)");
+                const DWORD err = GetLastError();
+                Core::Logger::Error("ProcessInjector: 虚拟内存分配失败 (VirtualAllocEx failed), err=" + std::to_string(err));
+                setFailureReason("VirtualAllocEx failed, err=" + std::to_string(err));
                 return false;
             }
             
             // 步骤 2: 将 DLL 路径写入目标进程
             if (!WriteProcessMemory(hProcess, remoteDllPath, dllPath.c_str(), dllPathSize, NULL)) {
-                Core::Logger::Error("ProcessInjector: 写入进程内存失败 (WriteProcessMemory failed)");
+                const DWORD err = GetLastError();
+                Core::Logger::Error("ProcessInjector: 写入进程内存失败 (WriteProcessMemory failed), err=" + std::to_string(err));
+                setFailureReason("WriteProcessMemory failed, err=" + std::to_string(err));
                 VirtualFreeEx(hProcess, remoteDllPath, 0, MEM_RELEASE);
                 return false;
             }
@@ -45,7 +56,9 @@ namespace Injection {
             // 步骤 3: 获取 LoadLibraryW 地址 (Kernel32.dll 在所有进程中地址相同)
             HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
             if (!hKernel32) {
-                Core::Logger::Error("ProcessInjector: 获取 Kernel32 句柄失败");
+                const DWORD err = GetLastError();
+                Core::Logger::Error("ProcessInjector: 获取 Kernel32 句柄失败, err=" + std::to_string(err));
+                setFailureReason("GetModuleHandleW(kernel32.dll) failed, err=" + std::to_string(err));
                 VirtualFreeEx(hProcess, remoteDllPath, 0, MEM_RELEASE);
                 return false;
             }
@@ -53,7 +66,9 @@ namespace Injection {
             LPTHREAD_START_ROUTINE loadLibraryAddr = 
                 (LPTHREAD_START_ROUTINE)GetProcAddress(hKernel32, "LoadLibraryW");
             if (!loadLibraryAddr) {
-                Core::Logger::Error("ProcessInjector: 获取 LoadLibraryW 地址失败");
+                const DWORD err = GetLastError();
+                Core::Logger::Error("ProcessInjector: 获取 LoadLibraryW 地址失败, err=" + std::to_string(err));
+                setFailureReason("GetProcAddress(LoadLibraryW) failed, err=" + std::to_string(err));
                 VirtualFreeEx(hProcess, remoteDllPath, 0, MEM_RELEASE);
                 return false;
             }
@@ -70,7 +85,9 @@ namespace Injection {
             );
             
             if (!hThread) {
-                Core::Logger::Error("ProcessInjector: 创建远程线程失败 (CreateRemoteThread failed)");
+                const DWORD err = GetLastError();
+                Core::Logger::Error("ProcessInjector: 创建远程线程失败 (CreateRemoteThread failed), err=" + std::to_string(err));
+                setFailureReason("CreateRemoteThread failed, err=" + std::to_string(err));
                 VirtualFreeEx(hProcess, remoteDllPath, 0, MEM_RELEASE);
                 return false;
             }
@@ -85,15 +102,21 @@ namespace Injection {
                 // 注意：GetExitCodeThread 返回 DWORD；在 64 位进程中我们仅用它判断是否为 0（NULL）
                 if (GetExitCodeThread(hThread, &exitCode)) {
                     ok = (exitCode != 0 && exitCode != STILL_ACTIVE);
+                    if (!ok) {
+                        setFailureReason("LoadLibraryW returned 0");
+                    }
                 } else {
                     DWORD err = GetLastError();
+                    setFailureReason("GetExitCodeThread failed, err=" + std::to_string(err));
                     Core::Logger::Warn("ProcessInjector: 获取远程线程退出码失败 (GetExitCodeThread failed), err=" + std::to_string(err));
                 }
             } else if (waitRc == WAIT_TIMEOUT) {
                 // 超时意味着远程线程可能仍在读取 remoteDllPath；此时释放远程内存可能导致 UAF
+                setFailureReason("WaitForSingleObject timeout(5000ms)");
                 Core::Logger::Warn("ProcessInjector: 等待远程线程超时(5000ms)，注入结果未知；为避免 UAF 将不释放远程路径内存");
             } else {
                 DWORD err = GetLastError();
+                setFailureReason("WaitForSingleObject failed, rc=" + std::to_string(waitRc) + ", err=" + std::to_string(err));
                 Core::Logger::Error("ProcessInjector: 等待远程线程失败 (WaitForSingleObject failed), rc=" + std::to_string(waitRc) +
                                     ", err=" + std::to_string(err));
             }
@@ -105,11 +128,15 @@ namespace Injection {
             }
 
             if (ok) {
+                setFailureReason("");
                 Core::Logger::Info("ProcessInjector: 注入成功 (LoadLibraryW 返回非空)");
                 return true;
             }
             if (waitRc == WAIT_OBJECT_0) {
                 Core::Logger::Error("ProcessInjector: 注入失败 (LoadLibraryW 返回 0)");
+            }
+            if (failureReason && failureReason->empty()) {
+                *failureReason = "unknown injector failure";
             }
             return false;
         }


### PR DESCRIPTION
## 概要
本 PR 使子进程 DLL 注入日志与真实注入结果严格一致，并补充可直接用于定位问题的失败原因。

## 问题
注入失败场景下，上层日志未稳定携带注入器侧的具体失败原因，增加了排障歧义。

## 变更内容
- `ProcessInjector::InjectDll` 新增可选输出参数 `failureReason`。
- 在各失败路径记录明确原因，包括：
  - `VirtualAllocEx` / `WriteProcessMemory` / `GetModuleHandleW` / `GetProcAddress` / `CreateRemoteThread` 失败（附 `GetLastError`）。
  - `WaitForSingleObject` 超时或失败细节。
  - `GetExitCodeThread` 失败细节。
  - `LoadLibraryW` 返回 `0`。
- `DetourCreateProcessW` 与 `DetourCreateProcessA` 在注入失败日志中追加上述失败原因。
- 成功日志仅在真实注入成功时输出。

## 影响评估
- 不改变注入控制流程与行为路径。
- 提升可观测性，减少故障定位中的误判。

## 验证说明
- 已对变更路径进行静态审查。
- 本次未执行运行期构建与测试。
