### PR TITLE
适配 Antigravity IDE 2.0 主进程重命名

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-# ============================================================
+﻿# ============================================================
 #  Antigravity-Proxy 编译脚本
 #  PowerShell Build Script for Windows
 # ============================================================
@@ -264,7 +264,11 @@ if ($SkipTests) {
 Write-Step "查找编译产物..."
 
 $dllPattern = if ($Config -eq "Debug") { "version*.dll" } else { "version.dll" }
-$dllPath = Get-ChildItem -Path $BuildDir -Recurse -Filter $dllPattern | Select-Object -First 1
+# 优先查找配置子目录（Visual Studio 产物路径），若无则在根目录查找（Ninja/Make 产物路径）
+$dllPath = Get-ChildItem -Path (Join-Path $BuildDir $Config) -Filter $dllPattern -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $dllPath) {
+    $dllPath = Get-ChildItem -Path $BuildDir -Filter $dllPattern -ErrorAction SilentlyContinue | Select-Object -First 1
+}
 
 if (-not $dllPath) {
     Write-Error "未找到编译产物 DLL"
@@ -323,7 +327,7 @@ $configJson = @{
     # 子进程注入排除列表（大小写不敏感，支持子串匹配）
     child_injection_exclude = @()
     # 目标进程列表（空数组=注入所有子进程）
-    target_processes = @("language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe")
+    target_processes = @("language_server", "Antigravity.exe", "Antigravity IDE.exe", "node.exe")
     proxy_rules = @{
         # 端口白名单: 仅代理 HTTP(80) 和 HTTPS(443)，空数组=代理所有端口
         allowed_ports = @(80, 443)
@@ -507,7 +511,7 @@ Test-NetConnection -ComputerName 127.0.0.1 -Port 7890
 ### 配置示例
 ```json
 {
-    "target_processes": ["language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
+    "target_processes": ["language_server", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
     "child_injection_mode": "filtered",
     "child_injection_exclude": ["unwanted_process.exe"]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-﻿# ============================================================
+# ============================================================
 #  Antigravity-Proxy 编译脚本
 #  PowerShell Build Script for Windows
 # ============================================================
@@ -323,7 +323,7 @@ $configJson = @{
     # 子进程注入排除列表（大小写不敏感，支持子串匹配）
     child_injection_exclude = @()
     # 目标进程列表（空数组=注入所有子进程）
-    target_processes = @("language_server_windows", "Antigravity.exe", "node.exe")
+    target_processes = @("language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe")
     proxy_rules = @{
         # 端口白名单: 仅代理 HTTP(80) 和 HTTPS(443)，空数组=代理所有端口
         allowed_ports = @(80, 443)
@@ -507,7 +507,7 @@ Test-NetConnection -ComputerName 127.0.0.1 -Port 7890
 ### 配置示例
 ```json
 {
-    "target_processes": ["language_server_windows", "Antigravity.exe", "node.exe"],
+    "target_processes": ["language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
     "child_injection_mode": "filtered",
     "child_injection_exclude": ["unwanted_process.exe"]
 }

--- a/resources/config-web/index.html
+++ b/resources/config-web/index.html
@@ -1426,7 +1426,7 @@
           child_injection: true,
           child_injection_mode: "filtered",
           child_injection_exclude: [],
-          target_processes: ["language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
+          target_processes: ["language_server", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
           proxy_rules: {
             allowed_ports: [80, 443],
             dns_mode: "direct",

--- a/resources/config-web/index.html
+++ b/resources/config-web/index.html
@@ -1426,7 +1426,7 @@
           child_injection: true,
           child_injection_mode: "filtered",
           child_injection_exclude: [],
-          target_processes: ["language_server_windows", "Antigravity.exe", "node.exe"],
+          target_processes: ["language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
           proxy_rules: {
             allowed_ports: [80, 443],
             dns_mode: "direct",

--- a/src/hooks/Hooks.cpp
+++ b/src/hooks/Hooks.cpp
@@ -319,7 +319,8 @@ struct AntLocationEvidence {
 };
 
 static bool IsCurrentAntigravityMainProcess() {
-    return ToLowerAsciiCopy(GetCurrentProcessBaseName()) == "antigravity.exe";
+    std::string procName = ToLowerAsciiCopy(GetCurrentProcessBaseName());
+    return procName == "antigravity.exe" || procName == "antigravity ide.exe";
 }
 
 static void CloseSocketCompat(SOCKET s) {

--- a/src/hooks/Hooks.cpp
+++ b/src/hooks/Hooks.cpp
@@ -643,14 +643,14 @@ static bool ShouldAutoInjectLanguageServerNodeChild(const Core::Config& config, 
     if (lowerChild != "node.exe" && lowerChild != "node") return false;
 
     const std::string lowerCurrent = ToLowerAsciiCopy(GetCurrentProcessBaseName());
-    return lowerCurrent.find("language_server_windows") != std::string::npos;
+    return lowerCurrent.find("language_server") != std::string::npos;
 }
 
 static void LogLanguageServerNodeCompatInjectOnce(const std::string& childProcessName) {
     std::call_once(g_languageServerNodeCompatLogOnce, [&childProcessName]() {
         const std::string currentProcessName = GetCurrentProcessBaseName();
         Core::Logger::Warn(
-            "[兼容] 检测到 " + (currentProcessName.empty() ? std::string("language_server_windows 子进程") : currentProcessName) +
+            "[兼容] 检测到 " + (currentProcessName.empty() ? std::string("language_server 子进程") : currentProcessName) +
             " 派生了关键子进程 " + childProcessName +
             "；为兼容新版 Antigravity 对话链路，filtered 模式下将自动继承注入。"
             " 如需关闭该行为，请将 node.exe 加入 child_injection_exclude。");


### PR DESCRIPTION
Antigravity IDE 升级至 2.0 后，主进程的可执行文件名由 Antigravity.exe 变更为 Antigravity IDE.exe，导致代理 DLL 无法正确识别主进程，网络请求拦截失效。

修改内容：
1. src/hooks/Hooks.cpp：IsCurrentAntigravityMainProcess() 增加对 antigravity ide.exe 的匹配，向下兼容旧版 antigravity.exe
2. build.ps1：默认 config.json 的 target_processes 增补 Antigravity IDE.exe，确保新装用户开箱即用
3. resources/config-web/index.html：同步更新配置工具中的默认值，保持一致性

已在 Windows x64 本地编译并部署，实测 Antigravity IDE 2.0 网络请求可正常被代理拦截。