### PR TITLE
feat: add CLI launcher and Antigravity 2.0 process support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,14 @@ target_include_directories(version PRIVATE "src/hde/")
 # Link WS2_32
 target_link_libraries(version PRIVATE ws2_32)
 
+# CLI launcher: starts agy.exe suspended, injects version.dll, then resumes it.
+add_executable(agy-proxy-launcher
+  "src/tools/AgyProxyLauncher.cpp"
+)
+target_include_directories(agy-proxy-launcher PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+
 if(WIN32)
   set_target_properties(version PROPERTIES PREFIX "")
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)   

--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ curl -x http://127.0.0.1:7890 https://www.google.com -I
 
 把 `version.dll` 和 `config.json` 复制到 **Antigravity 主程序目录**（与 `Antigravity.exe` 同级）。然后启动 Antigravity，搞定。
 
+如果你使用 **Antigravity CLI**，也需要把同一组文件复制到 `agy.exe` 同级目录：
+
+```powershell
+cd "$env:LOCALAPPDATA\agy\bin"
+```
+
+本仓库也提供部署脚本。构建后可执行：
+
+```powershell
+.\scripts\deploy-antigravity.ps1
+```
+
+默认会部署到 Antigravity IDE 和 Antigravity CLI；Antigravity 2.0 仅用于诊断时可加 `-IncludeDesktop`。
+
 #### Windows 常见目录 + 快速跳转
 
 一般情况下 Antigravity 会装在：
@@ -721,14 +735,26 @@ target_link_libraries(version PRIVATE ws2_32)
         "recv": 5000
     },
     "child_injection": true,
-    "target_processes": [],
+    "child_injection_mode": "filtered",
+    "target_processes": [
+        "agy.exe",
+        "Antigravity.exe",
+        "Antigravity IDE.exe",
+        "language_server.exe",
+        "language_server_windows",
+        "node.exe"
+    ],
     "proxy_rules": {
         "allowed_ports": [80, 443],
         "dns_mode": "direct",
-        "ipv6_mode": "proxy"
+        "ipv6_mode": "proxy",
+        "udp_mode": "block",
+        "udp_fallback": "block"
     }
 }
 ```
+
+如果你的代理软件区分 mixed-port 和 SOCKS5 端口，请确认 `proxy.type` 和 `proxy.port` 匹配。Clash/Mihomo 常见 mixed-port 是 `7890`，SOCKS5 独立端口常见是 `7891`。
 
 #### Step 3: 部署 DLL / Deploy DLL
 
@@ -742,6 +768,40 @@ target_link_libraries(version PRIVATE ws2_32)
 ```
 
 启动目标程序，完成！🎉
+
+#### Antigravity CLI
+
+Antigravity CLI 的主程序通常位于：
+
+```powershell
+$env:LOCALAPPDATA\agy\bin\agy.exe
+```
+
+将 `version.dll` 和 `config.json` 放到 `agy.exe` 同级目录。启动 CLI 后，优先检查：
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\agy\bin\logs"
+```
+
+如果直接启动 `agy.exe` 没有生成代理日志，请改用构建产物里的 `agy-proxy-launcher.exe`：
+
+```powershell
+agyp
+```
+
+该启动器会启动 `agy.exe`、注入同目录 `version.dll`，然后等待 CLI 退出。先用下面命令做轻量验证：
+
+```powershell
+agyp -- --version
+```
+
+如果日志里出现 `Antigravity-Proxy DLL 已加载` 和 `所有 API Hook 安装成功`，说明 CLI 已被 launcher 覆盖。实际发起请求后，再看是否出现 `SOCKS5: 隧道建立成功`。
+
+`agyp` 默认会继承你运行命令时的当前工作目录，因此在项目目录里执行 `agyp` 会让 Antigravity CLI 进入该项目目录。需要显式指定目录时可用：
+
+```powershell
+agyp --cwd "E:\your\project"
+```
 
 ### 配置文件详解 / Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,11 @@ cd "$env:LOCALAPPDATA\agy\bin"
 .\scripts\deploy-antigravity.ps1
 ```
 
-默认会部署到 Antigravity IDE 和 Antigravity CLI；Antigravity 2.0 仅用于诊断时可加 `-IncludeDesktop`。
+默认会部署到 Antigravity CLI；Antigravity 2.0 可加 `-IncludeDesktop`。如果 Antigravity IDE 安装在自定义目录，请显式传入：
+
+```powershell
+.\scripts\deploy-antigravity.ps1 -IdeDir "D:\Apps\Antigravity"
+```
 
 #### Windows 常见目录 + 快速跳转
 
@@ -800,7 +804,7 @@ agyp -- --version
 `agyp` 默认会继承你运行命令时的当前工作目录，因此在项目目录里执行 `agyp` 会让 Antigravity CLI 进入该项目目录。需要显式指定目录时可用：
 
 ```powershell
-agyp --cwd "E:\your\project"
+agyp --cwd "D:\path\to\project"
 ```
 
 ### 配置文件详解 / Configuration Reference

--- a/README_EN.md
+++ b/README_EN.md
@@ -230,6 +230,20 @@ You need two files:
 
 Copy `version.dll` and `config.json` to Antigravity’s main program directory (next to `Antigravity.exe`). Then launch Antigravity — done.
 
+If you use **Antigravity CLI**, copy the same files next to `agy.exe`:
+
+```powershell
+cd "$env:LOCALAPPDATA\agy\bin"
+```
+
+This repository also includes a deployment script. After building, run:
+
+```powershell
+.\scripts\deploy-antigravity.ps1
+```
+
+By default it deploys to Antigravity IDE and Antigravity CLI. Pass `-IncludeDesktop` only when you want to deploy to Antigravity 2.0 for diagnostics.
+
 #### Common Windows Path + Quick Jump
 
 In most cases, Antigravity is installed at:
@@ -697,9 +711,26 @@ Edit `config.json`:
         "recv": 5000
     },
     "child_injection": true,
-    "target_processes": []
+    "child_injection_mode": "filtered",
+    "target_processes": [
+        "agy.exe",
+        "Antigravity.exe",
+        "Antigravity IDE.exe",
+        "language_server.exe",
+        "language_server_windows",
+        "node.exe"
+    ],
+    "proxy_rules": {
+        "allowed_ports": [80, 443],
+        "dns_mode": "direct",
+        "ipv6_mode": "proxy",
+        "udp_mode": "block",
+        "udp_fallback": "block"
+    }
 }
 ```
+
+If your proxy client separates mixed-port and SOCKS5 ports, make sure `proxy.type` matches `proxy.port`. Clash/Mihomo often use `7890` for mixed-port and `7891` for a dedicated SOCKS5 port.
 
 #### Step 3: Deploy DLL
 
@@ -713,6 +744,40 @@ Target Application Directory/
 ```
 
 Launch the target application, done! 🎉
+
+#### Antigravity CLI
+
+Antigravity CLI is usually located at:
+
+```powershell
+$env:LOCALAPPDATA\agy\bin\agy.exe
+```
+
+Put `version.dll` and `config.json` next to `agy.exe`. After launching the CLI, check:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\agy\bin\logs"
+```
+
+If launching `agy.exe` directly does not create proxy logs, use the built `agy-proxy-launcher.exe` instead:
+
+```powershell
+agyp
+```
+
+The launcher starts `agy.exe`, injects the colocated `version.dll`, then waits for the CLI process to exit. For a light validation run:
+
+```powershell
+agyp -- --version
+```
+
+If the log contains `Antigravity-Proxy DLL 已加载` and `所有 API Hook 安装成功`, the CLI is covered by the launcher. After real network requests, check for `SOCKS5: 隧道建立成功`.
+
+`agyp` inherits the current working directory by default, so running it from a project directory starts Antigravity CLI in that project. To override it explicitly:
+
+```powershell
+agyp --cwd "E:\your\project"
+```
 
 ### Configuration Reference
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -242,7 +242,11 @@ This repository also includes a deployment script. After building, run:
 .\scripts\deploy-antigravity.ps1
 ```
 
-By default it deploys to Antigravity IDE and Antigravity CLI. Pass `-IncludeDesktop` only when you want to deploy to Antigravity 2.0 for diagnostics.
+By default it deploys to Antigravity CLI. Pass `-IncludeDesktop` to deploy to Antigravity 2.0. If Antigravity IDE is installed in a custom directory, pass it explicitly:
+
+```powershell
+.\scripts\deploy-antigravity.ps1 -IdeDir "D:\Apps\Antigravity"
+```
 
 #### Common Windows Path + Quick Jump
 
@@ -776,7 +780,7 @@ If the log contains `Antigravity-Proxy DLL 已加载` and `所有 API Hook 安�
 `agyp` inherits the current working directory by default, so running it from a project directory starts Antigravity CLI in that project. To override it explicitly:
 
 ```powershell
-agyp --cwd "E:\your\project"
+agyp --cwd "D:\path\to\project"
 ```
 
 ### Configuration Reference

--- a/build.ps1
+++ b/build.ps1
@@ -265,13 +265,19 @@ Write-Step "查找编译产物..."
 
 $dllPattern = if ($Config -eq "Debug") { "version*.dll" } else { "version.dll" }
 $dllPath = Get-ChildItem -Path $BuildDir -Recurse -Filter $dllPattern | Select-Object -First 1
+$launcherPath = Get-ChildItem -Path $BuildDir -Recurse -Filter "agy-proxy-launcher.exe" | Select-Object -First 1
 
 if (-not $dllPath) {
     Write-Error "未找到编译产物 DLL"
     exit 1
 }
+if (-not $launcherPath) {
+    Write-Error "未找到 CLI 启动器 agy-proxy-launcher.exe"
+    exit 1
+}
 
 Write-Success "找到 DLL: $($dllPath.FullName)"
+Write-Success "找到 CLI 启动器: $($launcherPath.FullName)"
 
 # ============================================================
 # 步骤 7: 创建输出目录并复制文件
@@ -285,6 +291,10 @@ if (-not (Test-Path $OutputDir)) {
 
 Copy-Item $dllPath.FullName -Destination $OutputDir -Force
 Write-Success "DLL 已复制到 output 目录"
+Copy-Item $launcherPath.FullName -Destination $OutputDir -Force
+Write-Success "CLI 启动器已复制到 output 目录"
+Copy-Item $launcherPath.FullName -Destination (Join-Path $OutputDir "agyp.exe") -Force
+Write-Success "CLI 短命令别名 agyp.exe 已复制到 output 目录"
 
 # ============================================================
 # 步骤 8: 生成配置文件
@@ -323,7 +333,7 @@ $configJson = @{
     # 子进程注入排除列表（大小写不敏感，支持子串匹配）
     child_injection_exclude = @()
     # 目标进程列表（空数组=注入所有子进程）
-    target_processes = @("language_server_windows", "Antigravity.exe", "node.exe")
+    target_processes = @("agy.exe", "Antigravity.exe", "Antigravity IDE.exe", "language_server.exe", "language_server_windows", "node.exe")
     proxy_rules = @{
         # 端口白名单: 仅代理 HTTP(80) 和 HTTPS(443)，空数组=代理所有端口
         allowed_ports = @(80, 443)
@@ -507,7 +517,7 @@ Test-NetConnection -ComputerName 127.0.0.1 -Port 7890
 ### 配置示例
 ```json
 {
-    "target_processes": ["language_server_windows", "Antigravity.exe", "node.exe"],
+    "target_processes": ["agy.exe", "Antigravity.exe", "Antigravity IDE.exe", "language_server.exe", "language_server_windows", "node.exe"],
     "child_injection_mode": "filtered",
     "child_injection_exclude": ["unwanted_process.exe"]
 }

--- a/scripts/deploy-antigravity.ps1
+++ b/scripts/deploy-antigravity.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
     [string]$OutputDir = (Join-Path $PSScriptRoot "..\output"),
-    [string]$IdeDir = "E:\download\Antigravity",
+    [string]$IdeDir = "",
     [string]$CliDir = "$env:LOCALAPPDATA\agy\bin",
     [string]$DesktopDir = "$env:LOCALAPPDATA\Programs\antigravity",
     [switch]$IncludeDesktop,
@@ -46,6 +46,10 @@ function Deploy-ToTarget {
         [Parameter(Mandatory = $true)][string]$DllSource,
         [Parameter(Mandatory = $true)][string]$ConfigSource
     )
+
+    if ([string]::IsNullOrWhiteSpace($TargetDir)) {
+        return
+    }
 
     if (-not (Test-Path -LiteralPath $TargetDir)) {
         Write-Warning "Skip missing directory: $TargetDir"
@@ -110,7 +114,11 @@ if (-not (Test-Path -LiteralPath $launcherSource)) {
     throw "Missing artifact: $launcherSource. Run .\build.ps1 first."
 }
 
-Deploy-ToTarget -TargetDir $IdeDir -ExeName "Antigravity IDE.exe" -DllSource $dllSource -ConfigSource $configSource
+if ($IdeDir) {
+    Deploy-ToTarget -TargetDir $IdeDir -ExeName "Antigravity IDE.exe" -DllSource $dllSource -ConfigSource $configSource
+} else {
+    Write-Host "Antigravity IDE deployment skipped. Pass -IdeDir <path> if your IDE is installed in a custom directory."
+}
 Deploy-ToTarget -TargetDir $CliDir -ExeName "agy.exe" -DllSource $dllSource -ConfigSource $configSource
 Deploy-CliLauncher -TargetDir $CliDir -LauncherSource $launcherSource
 

--- a/scripts/deploy-antigravity.ps1
+++ b/scripts/deploy-antigravity.ps1
@@ -1,0 +1,121 @@
+# Deploy built Antigravity-Proxy artifacts to Antigravity app directories.
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$OutputDir = (Join-Path $PSScriptRoot "..\output"),
+    [string]$IdeDir = "E:\download\Antigravity",
+    [string]$CliDir = "$env:LOCALAPPDATA\agy\bin",
+    [string]$DesktopDir = "$env:LOCALAPPDATA\Programs\antigravity",
+    [switch]$IncludeDesktop,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath((Resolve-Path -LiteralPath $Path).Path)
+}
+
+function Get-NormalizedPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Copy-ProxyArtifact {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    if (Test-Path -LiteralPath $Destination) {
+        $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+        $backup = "$Destination.$timestamp.bak"
+        Copy-Item -LiteralPath $Destination -Destination $backup -Force
+        Write-Host "Backed up: $Destination -> $backup"
+    }
+
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+    Write-Host "Copied: $Source -> $Destination"
+}
+
+function Deploy-ToTarget {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$ExeName,
+        [Parameter(Mandatory = $true)][string]$DllSource,
+        [Parameter(Mandatory = $true)][string]$ConfigSource
+    )
+
+    if (-not (Test-Path -LiteralPath $TargetDir)) {
+        Write-Warning "Skip missing directory: $TargetDir"
+        return
+    }
+
+    $exePath = Join-Path $TargetDir $ExeName
+    if (-not (Test-Path -LiteralPath $exePath)) {
+        Write-Warning "Skip $TargetDir because $ExeName was not found"
+        return
+    }
+
+    $dllDest = Join-Path $TargetDir "version.dll"
+    $configDest = Join-Path $TargetDir "config.json"
+    $targetFull = Resolve-FullPath -Path $TargetDir
+
+    if (-not $Force) {
+        $answer = Read-Host "Deploy to $targetFull ? This will back up and overwrite version.dll/config.json if present. Type YES to continue"
+        if ($answer -ne "YES") {
+            Write-Host "Skipped: $targetFull"
+            return
+        }
+    }
+
+    if ($PSCmdlet.ShouldProcess($targetFull, "Deploy version.dll and config.json")) {
+        Copy-ProxyArtifact -Source $DllSource -Destination $dllDest
+        Copy-ProxyArtifact -Source $ConfigSource -Destination $configDest
+    }
+}
+
+function Deploy-CliLauncher {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$LauncherSource
+    )
+
+    if (-not (Test-Path -LiteralPath $TargetDir)) {
+        Write-Warning "Skip missing CLI directory: $TargetDir"
+        return
+    }
+
+    $launcherDest = Join-Path $TargetDir "agy-proxy-launcher.exe"
+    $shortAliasDest = Join-Path $TargetDir "agyp.exe"
+    if ($PSCmdlet.ShouldProcess($TargetDir, "Deploy agy-proxy-launcher.exe")) {
+        Copy-ProxyArtifact -Source $LauncherSource -Destination $launcherDest
+        Copy-ProxyArtifact -Source $LauncherSource -Destination $shortAliasDest
+    }
+}
+
+$outputFull = Get-NormalizedPath -Path $OutputDir
+$dllSource = Join-Path $outputFull "version.dll"
+$configSource = Join-Path $outputFull "config.json"
+$launcherSource = Join-Path $outputFull "agy-proxy-launcher.exe"
+
+if (-not (Test-Path -LiteralPath $dllSource)) {
+    throw "Missing artifact: $dllSource. Run .\build.ps1 first."
+}
+if (-not (Test-Path -LiteralPath $configSource)) {
+    throw "Missing artifact: $configSource. Run .\build.ps1 first."
+}
+if (-not (Test-Path -LiteralPath $launcherSource)) {
+    throw "Missing artifact: $launcherSource. Run .\build.ps1 first."
+}
+
+Deploy-ToTarget -TargetDir $IdeDir -ExeName "Antigravity IDE.exe" -DllSource $dllSource -ConfigSource $configSource
+Deploy-ToTarget -TargetDir $CliDir -ExeName "agy.exe" -DllSource $dllSource -ConfigSource $configSource
+Deploy-CliLauncher -TargetDir $CliDir -LauncherSource $launcherSource
+
+if ($IncludeDesktop) {
+    Deploy-ToTarget -TargetDir $DesktopDir -ExeName "Antigravity.exe" -DllSource $dllSource -ConfigSource $configSource
+} else {
+    Write-Host "Desktop Antigravity 2.0 deployment skipped. Pass -IncludeDesktop to deploy there for diagnostics."
+}

--- a/src/hooks/Hooks.cpp
+++ b/src/hooks/Hooks.cpp
@@ -713,6 +713,15 @@ static LPFN_CONNECTEX GetOriginalConnectExForSocket(SOCKET s) {
 static void LogRuntimeConfigSummaryOnce() {
     std::call_once(g_runtimeConfigLogOnce, []() {
         const auto& config = Core::Config::Instance();
+        char processPath[MAX_PATH] = {0};
+        std::string processName = "(unknown)";
+        if (GetModuleFileNameA(NULL, processPath, MAX_PATH) > 0) {
+            processName = processPath;
+            const size_t slash = processName.find_last_of("\\/");
+            if (slash != std::string::npos) {
+                processName = processName.substr(slash + 1);
+            }
+        }
 
         std::string ports;
         if (config.rules.allowed_ports.empty()) {
@@ -724,6 +733,7 @@ static void LogRuntimeConfigSummaryOnce() {
             }
         }
 
+        Core::Logger::Info("运行进程: name=" + processName + ", pid=" + std::to_string(GetCurrentProcessId()));
         Core::Logger::Info(
             "配置摘要: proxy=" + config.proxy.type + "://" + config.proxy.host + ":" + std::to_string(config.proxy.port) +
             ", fake_ip=" + std::string(config.fakeIp.enabled ? "开" : "关") +

--- a/src/tools/AgyProxyLauncher.cpp
+++ b/src/tools/AgyProxyLauncher.cpp
@@ -1,0 +1,191 @@
+// Starts Antigravity CLI with antigravity-proxy injected.
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../injection/ProcessInjector.hpp"
+
+static std::wstring QuoteArg(const std::wstring& arg) {
+    if (arg.empty()) return L"\"\"";
+    bool needsQuotes = false;
+    for (wchar_t c : arg) {
+        if (c == L' ' || c == L'\t' || c == L'"') {
+            needsQuotes = true;
+            break;
+        }
+    }
+    if (!needsQuotes) return arg;
+
+    std::wstring result = L"\"";
+    size_t backslashes = 0;
+    for (wchar_t c : arg) {
+        if (c == L'\\') {
+            backslashes++;
+            continue;
+        }
+        if (c == L'"') {
+            result.append(backslashes * 2 + 1, L'\\');
+            result.push_back(c);
+            backslashes = 0;
+            continue;
+        }
+        result.append(backslashes, L'\\');
+        backslashes = 0;
+        result.push_back(c);
+    }
+    result.append(backslashes * 2, L'\\');
+    result.push_back(L'"');
+    return result;
+}
+
+static std::wstring GetDirectoryOf(const std::wstring& path) {
+    const size_t slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return L".";
+    return path.substr(0, slash);
+}
+
+static std::wstring GetModulePath() {
+    std::wstring buffer(MAX_PATH, L'\0');
+    DWORD len = GetModuleFileNameW(NULL, buffer.data(), (DWORD)buffer.size());
+    if (len == 0) return L"";
+    while (len >= buffer.size()) {
+        buffer.resize(buffer.size() * 2);
+        len = GetModuleFileNameW(NULL, buffer.data(), (DWORD)buffer.size());
+        if (len == 0) return L"";
+    }
+    buffer.resize(len);
+    return buffer;
+}
+
+static bool FileExists(const std::wstring& path) {
+    const DWORD attrs = GetFileAttributesW(path.c_str());
+    return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY) == 0;
+}
+
+static void PrintUsage() {
+    std::wcerr << L"Usage: agy-proxy-launcher.exe [--target path\\to\\agy.exe] [--dll path\\to\\version.dll] [--cwd path] [--] [agy args...]\n";
+}
+
+int wmain(int argc, wchar_t** argv) {
+    const std::wstring launcherPath = GetModulePath();
+    const std::wstring launcherDir = GetDirectoryOf(launcherPath);
+    std::wstring targetPath = launcherDir + L"\\agy.exe";
+    std::wstring dllPath = launcherDir + L"\\version.dll";
+    std::wstring workingDir;
+    std::vector<std::wstring> passthroughArgs;
+
+    for (int i = 1; i < argc; i++) {
+        const std::wstring arg = argv[i];
+        if (arg == L"--help" || arg == L"-h") {
+            PrintUsage();
+            return 0;
+        }
+        if (arg == L"--target") {
+            if (++i >= argc) {
+                std::wcerr << L"Missing value for --target\n";
+                return 2;
+            }
+            targetPath = argv[i];
+            continue;
+        }
+        if (arg == L"--dll") {
+            if (++i >= argc) {
+                std::wcerr << L"Missing value for --dll\n";
+                return 2;
+            }
+            dllPath = argv[i];
+            continue;
+        }
+        if (arg == L"--cwd") {
+            if (++i >= argc) {
+                std::wcerr << L"Missing value for --cwd\n";
+                return 2;
+            }
+            workingDir = argv[i];
+            continue;
+        }
+        if (arg == L"--") {
+            for (++i; i < argc; i++) passthroughArgs.push_back(argv[i]);
+            break;
+        }
+        passthroughArgs.push_back(arg);
+    }
+
+    if (!FileExists(targetPath)) {
+        std::wcerr << L"agy target not found: " << targetPath << L"\n";
+        return 2;
+    }
+    if (!FileExists(dllPath)) {
+        std::wcerr << L"proxy DLL not found: " << dllPath << L"\n";
+        return 2;
+    }
+
+    std::wstring commandLine = QuoteArg(targetPath);
+    for (const auto& arg : passthroughArgs) {
+        commandLine += L" ";
+        commandLine += QuoteArg(arg);
+    }
+
+    STARTUPINFOW si{};
+    si.cb = sizeof(si);
+    PROCESS_INFORMATION pi{};
+
+    std::vector<wchar_t> mutableCommandLine(commandLine.begin(), commandLine.end());
+    mutableCommandLine.push_back(L'\0');
+    if (workingDir.empty()) {
+        std::vector<wchar_t> cwd(MAX_PATH, L'\0');
+        DWORD len = GetCurrentDirectoryW((DWORD)cwd.size(), cwd.data());
+        if (len > 0) {
+            if (len >= cwd.size()) {
+                cwd.resize(len + 1);
+                len = GetCurrentDirectoryW((DWORD)cwd.size(), cwd.data());
+            }
+            if (len > 0 && len < cwd.size()) {
+                workingDir.assign(cwd.data(), len);
+            }
+        }
+    }
+    const wchar_t* childWorkingDir = workingDir.empty() ? NULL : workingDir.c_str();
+
+    if (!CreateProcessW(
+            targetPath.c_str(),
+            mutableCommandLine.data(),
+            NULL,
+            NULL,
+            TRUE,
+            CREATE_SUSPENDED,
+            NULL,
+            childWorkingDir,
+            &si,
+            &pi)) {
+        std::wcerr << L"CreateProcessW failed, err=" << GetLastError() << L"\n";
+        return 1;
+    }
+
+    std::string failureReason;
+    const bool injected = Injection::ProcessInjector::InjectDll(pi.hProcess, dllPath, &failureReason);
+    if (!injected) {
+        std::cerr << "DLL injection failed: " << failureReason << "\n";
+        TerminateProcess(pi.hProcess, 1);
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+        return 1;
+    }
+
+    ResumeThread(pi.hThread);
+    CloseHandle(pi.hThread);
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exitCode = 0;
+    if (!GetExitCodeProcess(pi.hProcess, &exitCode)) {
+        exitCode = 1;
+    }
+    CloseHandle(pi.hProcess);
+    return (int)exitCode;
+}


### PR DESCRIPTION
## Summary

This PR adds support for the new Antigravity CLI and Antigravity 2.0 process layout while keeping the existing `version.dll` injection flow for Antigravity IDE.

## Changes

- Add `agy-proxy-launcher.exe`, a small Windows launcher that starts `agy.exe` suspended, injects the colocated `version.dll`, then resumes the CLI process.
- Add `agyp.exe` as a short alias copied from the launcher during build/deployment.
- Include `language_server.exe` in the default target process list for Antigravity 2.0, in addition to the existing `language_server_windows` path.
- Add `scripts/deploy-antigravity.ps1` to deploy built artifacts to Antigravity IDE, Antigravity CLI, and optionally Antigravity 2.0.
- Update Chinese and English README sections with CLI launcher usage, working-directory behavior, and port guidance.
- Add runtime logging of process name and PID to make injection coverage easier to verify.

## Validation

Tested locally on Windows:

- `.uild.ps1 -Config Release -Arch x64 -SkipTests`
- `agyp -- --version`
- `agyp` from a project directory, confirming the launcher preserves the caller working directory
- Antigravity CLI traffic successfully proxied through SOCKS5
- Antigravity IDE still works with the existing colocated `version.dll` flow
- Antigravity 2.0 works after adding `language_server.exe` to the target process list

## Notes

The default proxy port remains `7890` for compatibility. The README now notes that Clash/Mihomo commonly use `7890` for mixed-port and `7891` for a dedicated SOCKS5 port.