### PR TITLE
feat: add dbghelp shim for Antigravity CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,23 +105,35 @@ target_include_directories(version PRIVATE "src/hde/")
 # Link WS2_32
 target_link_libraries(version PRIVATE ws2_32)
 
+# Build Antigravity CLI shim (输出名为 dbghelp.dll)
+add_library(dbghelp SHARED
+  "src/proxy/DbgHelpShim.cpp"
+)
+
 if(WIN32)
   set_target_properties(version PROPERTIES PREFIX "")
+  set_target_properties(dbghelp PROPERTIES PREFIX "")
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)   
     set_target_properties(version PROPERTIES OUTPUT_NAME "version")
+    set_target_properties(dbghelp PROPERTIES OUTPUT_NAME "dbghelp")
     set_target_properties(version PROPERTIES DEBUG_POSTFIX ".x64d")
+    set_target_properties(dbghelp PROPERTIES DEBUG_POSTFIX ".x64d")
     set_target_properties(version PROPERTIES RELEASE_POSTFIX "")
+    set_target_properties(dbghelp PROPERTIES RELEASE_POSTFIX "")
   else()
     set_target_properties(version PROPERTIES OUTPUT_NAME "version")
+    set_target_properties(dbghelp PROPERTIES OUTPUT_NAME "dbghelp")
     set_target_properties(version PROPERTIES DEBUG_POSTFIX ".x32d")
+    set_target_properties(dbghelp PROPERTIES DEBUG_POSTFIX ".x32d")
     set_target_properties(version PROPERTIES RELEASE_POSTFIX "")
+    set_target_properties(dbghelp PROPERTIES RELEASE_POSTFIX "")
   endif()
 endif()
 
 ###################
 #     INSTALL     #
 ###################
-install(TARGETS version RUNTIME DESTINATION "bin")
+install(TARGETS version dbghelp RUNTIME DESTINATION "bin")
 
 ###################
 #      TESTS      #

--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ curl -x http://127.0.0.1:7890 https://www.google.com -I
 
 ### Step 2: 准备文件 / Get the Files
 
-准备两份文件：
+准备以下文件：
 - `version.dll`
+- `dbghelp.dll`（仅 Antigravity CLI 需要）
 - `config.json`
 
 （可以从 Release 下载，或自行编译生成。）
@@ -232,12 +233,15 @@ curl -x http://127.0.0.1:7890 https://www.google.com -I
 
 把 `version.dll` 和 `config.json` 复制到 **Antigravity 主程序目录**（与 `Antigravity.exe` 同级）。然后启动 Antigravity，搞定。
 
+如果使用 **Antigravity CLI**，把 `dbghelp.dll`、`version.dll` 和 `config.json` 复制到 `agy.exe` 同级目录。`agy.exe` 会加载同目录 `dbghelp.dll`，再由它加载 `version.dll`，不需要额外启动器。
+
 #### Antigravity 2.0 注意事项
 
 Antigravity 2.0 新增/改名了关键进程，默认配置已覆盖：
 
 ```json
 "target_processes": [
+  "agy.exe",
   "language_server.exe",
   "language_server_windows",
   "Antigravity.exe",
@@ -247,6 +251,8 @@ Antigravity 2.0 新增/改名了关键进程，默认配置已覆盖：
 ```
 
 如果你是从旧版本手动迁移 `config.json`，请确认 `child_injection` 仍为 `true`，并把上面的目标进程列表同步进去。2.0 环境如果存在多个启动目录，也要把 `version.dll` 和 `config.json` 放到实际启动的 Antigravity/IDE 目录中。
+
+Antigravity 更新后可能清理安装目录里的劫持文件；如果更新后不走代理，请重新复制这些文件。若代理软件区分 mixed-port 和 SOCKS5 端口，也要确认 `proxy.type` 和 `proxy.port` 匹配本机实际监听端口。
 
 更多现场记录见 `docs/antigravity-2.0-issue-85.md`。
 
@@ -716,6 +722,7 @@ target_link_libraries(version PRIVATE ws2_32)
 
 编译完成后，你会在 `output` 目录得到：
 - `version.dll` - 代理 DLL
+- `dbghelp.dll` - Antigravity CLI 劫持 DLL
 - `config.json` - 配置文件
 
 #### Step 2: 配置代理 / Configure Proxy
@@ -741,6 +748,7 @@ target_link_libraries(version PRIVATE ws2_32)
     "child_injection": true,
     "child_injection_mode": "filtered",
     "target_processes": [
+        "agy.exe",
         "language_server.exe",
         "language_server_windows",
         "Antigravity.exe",

--- a/README_EN.md
+++ b/README_EN.md
@@ -220,8 +220,9 @@ curl -x http://127.0.0.1:7890 https://www.google.com -I
 
 ### Step 2: Get the Files
 
-You need two files:
+You need these files:
 - `version.dll`
+- `dbghelp.dll` (Antigravity CLI only)
 - `config.json`
 
 (Download from Releases, or build them yourself.)
@@ -230,12 +231,15 @@ You need two files:
 
 Copy `version.dll` and `config.json` to Antigravity’s main program directory (next to `Antigravity.exe`). Then launch Antigravity — done.
 
+For **Antigravity CLI**, copy `dbghelp.dll`, `version.dll`, and `config.json` next to `agy.exe`. `agy.exe` loads the colocated `dbghelp.dll`, which then loads `version.dll`; no separate launcher is required.
+
 #### Antigravity 2.0 Notes
 
 Antigravity 2.0 added/renamed key processes. The default config now covers:
 
 ```json
 "target_processes": [
+  "agy.exe",
   "language_server.exe",
   "language_server_windows",
   "Antigravity.exe",
@@ -245,6 +249,8 @@ Antigravity 2.0 added/renamed key processes. The default config now covers:
 ```
 
 If you are migrating an old `config.json`, make sure `child_injection` is still `true` and sync the target process list above. If your 2.0 install has more than one launch directory, place `version.dll` and `config.json` in the actual Antigravity/IDE directory being launched.
+
+Antigravity updates may clean injected files from the install directory. If proxying stops after an update, copy the files again. If your proxy client separates mixed-port and SOCKS5 ports, make sure `proxy.type` and `proxy.port` match the actual local listener.
 
 More field notes: `docs/antigravity-2.0-issue-85.md`.
 
@@ -692,6 +698,7 @@ target_link_libraries(version PRIVATE ws2_32)
 
 After building, you'll get these files in the `output` directory:
 - `version.dll` - Proxy DLL
+- `dbghelp.dll` - Antigravity CLI shim DLL
 - `config.json` - Configuration file
 
 #### Step 2: Configure Proxy
@@ -717,6 +724,7 @@ Edit `config.json`:
     "child_injection": true,
     "child_injection_mode": "filtered",
     "target_processes": [
+        "agy.exe",
         "language_server.exe",
         "language_server_windows",
         "Antigravity.exe",

--- a/build.ps1
+++ b/build.ps1
@@ -265,13 +265,20 @@ Write-Step "查找编译产物..."
 
 $dllPattern = if ($Config -eq "Debug") { "version*.dll" } else { "version.dll" }
 $dllPath = Get-ChildItem -Path $BuildDir -Recurse -Filter $dllPattern | Select-Object -First 1
+$dbghelpPattern = if ($Config -eq "Debug") { "dbghelp*.dll" } else { "dbghelp.dll" }
+$dbghelpPath = Get-ChildItem -Path $BuildDir -Recurse -Filter $dbghelpPattern | Select-Object -First 1
 
 if (-not $dllPath) {
     Write-Error "未找到编译产物 DLL"
     exit 1
 }
+if (-not $dbghelpPath) {
+    Write-Error "未找到 Antigravity CLI dbghelp.dll 劫持产物"
+    exit 1
+}
 
 Write-Success "找到 DLL: $($dllPath.FullName)"
+Write-Success "找到 CLI dbghelp.dll: $($dbghelpPath.FullName)"
 
 # ============================================================
 # 步骤 7: 创建输出目录并复制文件
@@ -285,6 +292,8 @@ if (-not (Test-Path $OutputDir)) {
 
 Copy-Item $dllPath.FullName -Destination $OutputDir -Force
 Write-Success "DLL 已复制到 output 目录"
+Copy-Item $dbghelpPath.FullName -Destination $OutputDir -Force
+Write-Success "CLI dbghelp.dll 已复制到 output 目录"
 
 # ============================================================
 # 步骤 8: 生成配置文件
@@ -323,8 +332,8 @@ $configJson = @{
     # 子进程注入排除列表（大小写不敏感，支持子串匹配）
     child_injection_exclude = @()
     # 目标进程列表（空数组=注入所有子进程）
-    # 兼容 Antigravity 2.0 新增的 language_server.exe，同时保留旧版 language_server_windows* 命名。
-    target_processes = @("language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe")
+    # 兼容 Antigravity 2.0 新增的 language_server.exe，同时覆盖 Antigravity CLI 的 agy.exe。
+    target_processes = @("agy.exe", "language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe")
     proxy_rules = @{
         # 端口白名单: 仅代理 HTTP(80) 和 HTTPS(443)，空数组=代理所有端口
         allowed_ports = @(80, 443)
@@ -397,7 +406,10 @@ FAILED_PRECONDITION (code 400): User location is not supported for the API use.
 ### 1. 部署文件
 将以下文件复制到目标程序的目录：
 - ` version.dll ` (编译生成的 DLL)
+- ` dbghelp.dll ` (Antigravity CLI 的 agy.exe 需要)
 - ` config.json ` (配置文件)
+
+Antigravity CLI 需要把 `dbghelp.dll`、`version.dll` 和 `config.json` 放到 `agy.exe` 同级目录；Antigravity 桌面端/IDE 仍只需要 `version.dll` 和 `config.json`。
 
 ### 2. 配置代理
 编辑 `config.json`，设置代理服务器地址：
@@ -508,7 +520,7 @@ Test-NetConnection -ComputerName 127.0.0.1 -Port 7890
 ### 配置示例
 ```json
 {
-    "target_processes": ["language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
+    "target_processes": ["agy.exe", "language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
     "child_injection_mode": "filtered",
     "child_injection_exclude": ["unwanted_process.exe"]
 }

--- a/resources/config-web/index.html
+++ b/resources/config-web/index.html
@@ -1426,7 +1426,7 @@
           child_injection: true,
           child_injection_mode: "filtered",
           child_injection_exclude: [],
-          target_processes: ["language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
+          target_processes: ["agy.exe", "language_server.exe", "language_server_windows", "Antigravity.exe", "Antigravity IDE.exe", "node.exe"],
           proxy_rules: {
             allowed_ports: [80, 443],
             dns_mode: "direct",

--- a/src/proxy/DbgHelpShim.cpp
+++ b/src/proxy/DbgHelpShim.cpp
@@ -1,0 +1,60 @@
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+namespace {
+
+DWORD WINAPI LoadVersionDll(LPVOID) {
+    LoadLibraryW(L"version.dll");
+    return 0;
+}
+
+HMODULE LoadSystemDbgHelp() {
+    static HMODULE module = []() -> HMODULE {
+        wchar_t systemDir[MAX_PATH] = {};
+        const UINT len = GetSystemDirectoryW(systemDir, MAX_PATH);
+        if (len == 0 || len >= MAX_PATH) {
+            return nullptr;
+        }
+
+        wchar_t path[MAX_PATH] = {};
+        lstrcpynW(path, systemDir, MAX_PATH);
+        lstrcatW(path, L"\\dbghelp.dll");
+        return LoadLibraryW(path);
+    }();
+    return module;
+}
+
+using SymFromAddrFn = BOOL(WINAPI*)(HANDLE, DWORD64, DWORD64*, void*);
+
+}  // namespace
+
+extern "C" __declspec(dllexport) BOOL WINAPI SymFromAddr(
+    HANDLE process,
+    DWORD64 address,
+    DWORD64* displacement,
+    void* symbol) {
+    const HMODULE dbghelp = LoadSystemDbgHelp();
+    if (!dbghelp) {
+        return FALSE;
+    }
+
+    const auto fn = reinterpret_cast<SymFromAddrFn>(GetProcAddress(dbghelp, "SymFromAddr"));
+    if (!fn) {
+        return FALSE;
+    }
+    return fn(process, address, displacement, symbol);
+}
+
+BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID) {
+    if (reason == DLL_PROCESS_ATTACH) {
+        DisableThreadLibraryCalls(module);
+        const HANDLE thread = CreateThread(nullptr, 0, LoadVersionDll, nullptr, 0, nullptr);
+        if (thread) {
+            CloseHandle(thread);
+        }
+    }
+    return TRUE;
+}

--- a/src/proxy/DbgHelpShim.cpp
+++ b/src/proxy/DbgHelpShim.cpp
@@ -51,10 +51,7 @@ extern "C" __declspec(dllexport) BOOL WINAPI SymFromAddr(
 BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID) {
     if (reason == DLL_PROCESS_ATTACH) {
         DisableThreadLibraryCalls(module);
-        const HANDLE thread = CreateThread(nullptr, 0, LoadVersionDll, nullptr, 0, nullptr);
-        if (thread) {
-            CloseHandle(thread);
-        }
+        LoadVersionDll(nullptr);
     }
     return TRUE;
 }


### PR DESCRIPTION
## Summary

This PR adds a minimal `dbghelp.dll` shim for Antigravity CLI (`agy.exe`) so the CLI can load the existing `version.dll` proxy without a separate launcher.

## Changes

- Add a small `dbghelp.dll` shim that exports `SymFromAddr`.
- Load colocated `version.dll` from the shim when `agy.exe` loads `dbghelp.dll`.
- Forward `SymFromAddr` calls to the system `dbghelp.dll`.
- Copy `dbghelp.dll` to `output` during build.
- Add `agy.exe` to the default target process list and config-web defaults.
- Document the CLI deployment flow in README / README_EN.

## Validation

Tested locally on Windows:

- `./build.ps1 -Config Release -Arch x64 -SkipTests`
- Confirmed `output` contains `version.dll`, `dbghelp.dll`, and `config.json`
- Confirmed `output` does not contain `agyp.exe` or `agy-proxy-launcher.exe`
- Confirmed current `agy.exe` imports `dbghelp.dll!SymFromAddr`
- Ran `agy.exe --version`
- Ran `agy.exe --print "Reply with OK only." --print-timeout 90s`
- Verified proxy logs show `version.dll` loaded, hooks installed, and SOCKS5 tunnels established to Google endpoints

## Notes

Thanks @CrazyBoyFeng for the review feedback about splitting concerns and keeping maintenance cost low.

Thanks @median-dxz for pointing out that `agy.exe` imports `dbghelp.dll` and suggesting the shim-based approach.