### PR TITLE
[codex] 添加 macOS 代理启动器支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/yuaotian/antigravity-proxy/actions"><img src="https://github.com/yuaotian/antigravity-proxy/actions/workflows/build.yml/badge.svg" alt="Build Status"/></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-BSD--2--Clause-blue.svg" alt="License"/></a>
-  <img src="https://img.shields.io/badge/platform-Windows%20x86%20%7C%20x64-lightgrey.svg" alt="Platform"/>
+  <img src="https://img.shields.io/badge/platform-Windows%20x86%2Fx64%20%7C%20macOS%20launcher-lightgrey.svg" alt="Platform"/>
   <img src="https://img.shields.io/badge/C%2B%2B-17-00599C.svg" alt="C++17"/>
   <img src="https://img.shields.io/badge/hook-MinHook-orange.svg" alt="MinHook"/>
 </p>
@@ -32,6 +32,7 @@
 - [🔧 工作原理 / How It Works](#-工作原理--how-it-works)
 - [🛠️ 编译构建 / Build](#️-编译构建--build)
 - [📝 使用方法 / Usage](#-使用方法--usage)
+- [🍎 macOS 使用指南 / macOS Guide](#-macos-使用指南--macos-guide)
 - [🐧 WSL 环境使用指南 / WSL Guide](#-wsl-环境使用指南--wsl-guide)
 - [🚀 进阶玩法 / Advanced Usage](#-进阶玩法--advanced-usage)
 - [📄 许可证 / License](#-许可证--license)
@@ -160,6 +161,31 @@
 ## ⚡ Antigravity 快速开始 / Quick Start
 
 > 只想让 Antigravity 立刻能用？看这一节就够了。
+
+### macOS 快速开始
+
+macOS 不能直接使用 Windows 的 `version.dll` 注入方式。本仓库提供了 macOS 启动器：自动读取 Clash Verge/Mihomo 本地混合端口，并用 Chromium 代理参数与 `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`GRPC_PROXY` 环境变量启动 Antigravity。
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+如果你使用旧版或独立安装的 **Antigravity IDE.app**：
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor --app ide
+./scripts/macos-antigravity-proxy.sh restart --app ide
+```
+
+如果你想关闭 Clash Verge TUN，改为 System Proxy：
+
+```bash
+./scripts/macos-antigravity-proxy.sh clash-verge use-system-proxy
+./scripts/macos-antigravity-proxy.sh system-proxy on
+```
+
+详细说明见 [docs/macos.md](docs/macos.md)。
 
 ### Step 1: 准备代理 / Prepare a Proxy
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/yuaotian/antigravity-proxy/actions"><img src="https://github.com/yuaotian/antigravity-proxy/actions/workflows/build.yml/badge.svg" alt="Build Status"/></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-BSD--2--Clause-blue.svg" alt="License"/></a>
-  <img src="https://img.shields.io/badge/platform-Windows%20x86%20%7C%20x64-lightgrey.svg" alt="Platform"/>
+  <img src="https://img.shields.io/badge/platform-Windows%20x86%2Fx64%20%7C%20macOS%20launcher-lightgrey.svg" alt="Platform"/>
   <img src="https://img.shields.io/badge/C%2B%2B-17-00599C.svg" alt="C++17"/>
   <img src="https://img.shields.io/badge/hook-MinHook-orange.svg" alt="MinHook"/>
 </p>
@@ -32,6 +32,7 @@
 - [🔧 How It Works](#-how-it-works)
 - [🛠️ Build](#️-build)
 - [📝 Usage](#-usage)
+- [🍎 macOS Guide](#-macos-guide)
 - [🚀 Advanced Usage](#-advanced-usage)
 - [📄 License](#-license)
 - [👤 Author](#-author)
@@ -158,6 +159,31 @@ Have you ever encountered these situations?
 ## ⚡ Antigravity Quick Start
 
 > If you only care about getting Antigravity working right now, this is the shortest path.
+
+### macOS Quick Start
+
+macOS cannot use the Windows `version.dll` injection path directly. This repository includes an opt-in macOS launcher that detects the local Clash Verge/Mihomo mixed port and starts Antigravity with Chromium proxy flags plus `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`GRPC_PROXY` environment variables.
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+For **Antigravity IDE.app**:
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor --app ide
+./scripts/macos-antigravity-proxy.sh restart --app ide
+```
+
+To switch Clash Verge from TUN mode to macOS System Proxy:
+
+```bash
+./scripts/macos-antigravity-proxy.sh clash-verge use-system-proxy
+./scripts/macos-antigravity-proxy.sh system-proxy on
+```
+
+See [docs/macos_en.md](docs/macos_en.md) for details.
 
 ### Step 1: Prepare a Proxy
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,123 @@
+# macOS 使用指南
+
+Windows 版本通过 `version.dll` 劫持和 MinHook 拦截 Winsock 调用。macOS 不能直接复用这套 DLL 注入链路，尤其是 Electron 应用和子进程会受到签名、SIP、hardened runtime 等限制。
+
+本项目的 macOS 方案改为“代理化启动 Antigravity”：
+
+- 给 Antigravity 主进程添加 Chromium/Electron `--proxy-server` 参数。
+- 给 Antigravity 子进程继承 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY`、`GRPC_PROXY`、`NO_PROXY` 等环境变量。
+- 可选开启 macOS System Proxy，并关闭 Clash Verge TUN。
+
+这不会在 socket 层透明劫持所有程序，只影响通过该脚本启动的 Antigravity 及其子进程；对 Antigravity 的 Electron 网络栈、Go `language_server` 的 `net/http`/gRPC 链路更贴近实际有效路径。
+
+## 快速开始
+
+先确保 Clash Verge 已启动，并且本地混合端口可用：
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+```
+
+如果你使用 Clash Verge Rev，脚本会优先读取：
+
+- `~/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/clash-verge.yaml` 的 `mixed-port`
+- `~/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/verge.yaml` 的 `verge_mixed_port`
+
+例如 Clash Verge Rev 常见配置是 `127.0.0.1:7897`。
+
+只让 Antigravity 走代理：
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+如果你用的是 `/Applications/Antigravity IDE.app`：
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor --app ide
+./scripts/macos-antigravity-proxy.sh restart --app ide
+```
+
+如果 Antigravity 无法正常退出，可以改用：
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart --force-kill
+```
+
+## 不走 TUN，改用系统代理
+
+关闭 Clash Verge TUN、打开 System Proxy 的配置可以用：
+
+```bash
+./scripts/macos-antigravity-proxy.sh clash-verge use-system-proxy
+```
+
+该命令会备份并修改 Clash Verge 的 `verge.yaml`：
+
+- `enable_tun_mode: false`
+- `enable_system_proxy: true`
+- `enable_proxy_guard: true`
+
+如果 `/tmp/verge/verge-mihomo.sock` 可用，脚本还会通过 Mihomo 本地控制接口立即关闭运行态 TUN。若 Clash Verge UI 仍显示旧状态，可以重启 Clash Verge，或在 UI 里重新切换一次 System Proxy。
+
+也可以直接让脚本写入 macOS 网络服务代理：
+
+```bash
+./scripts/macos-antigravity-proxy.sh system-proxy on
+```
+
+回滚系统代理：
+
+```bash
+./scripts/macos-antigravity-proxy.sh system-proxy off
+```
+
+## 自定义端口
+
+如果你的 Clash/Mihomo 不是默认路径或端口：
+
+```bash
+ANTIGRAVITY_PROXY_HOST=127.0.0.1 \
+ANTIGRAVITY_PROXY_PORT=7890 \
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+如果 Antigravity 不在 `/Applications/Antigravity.app`：
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart --app "/path/to/Antigravity.app"
+```
+
+也可以用环境变量：
+
+```bash
+ANTIGRAVITY_APP=ide ./scripts/macos-antigravity-proxy.sh restart
+ANTIGRAVITY_APP_PATH="/Applications/Antigravity IDE.app" ./scripts/macos-antigravity-proxy.sh restart
+```
+
+## 验证
+
+查看代理和运行状态：
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+```
+
+你应该能看到：
+
+- `Detected proxy: 127.0.0.1:<port>`
+- `Proxy HTTP CONNECT test: ok`
+- Antigravity 进程命令行里有 `--proxy-server=http://127.0.0.1:<port>`
+- 对 Antigravity IDE，命令改为 `./scripts/macos-antigravity-proxy.sh doctor --app ide`
+
+脚本启动日志在：
+
+```text
+~/Library/Logs/antigravity-proxy-macos/
+```
+
+## 注意事项
+
+- 如果 Antigravity 日志仍出现 `User location is not supported for the API use.`，这通常是代理出口 IP 被服务端策略拒绝，不是本地代理没有生效。优先换出口 IP。
+- 已经运行中的 Antigravity 不会自动继承新的环境变量，所以需要通过 `restart` 重新启动。
+- Finder 直接双击 Antigravity 不会经过本脚本，也就不会带上这些代理环境变量。

--- a/docs/macos_en.md
+++ b/docs/macos_en.md
@@ -1,0 +1,119 @@
+# macOS Guide
+
+The Windows build works by loading `version.dll` and using MinHook to intercept Winsock calls. macOS cannot reuse that DLL injection path directly, especially for signed Electron apps and their child processes.
+
+The macOS support in this repository uses a launcher instead:
+
+- Adds Chromium/Electron `--proxy-server` flags to the Antigravity main process.
+- Passes `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `GRPC_PROXY`, and `NO_PROXY` to child processes such as `language_server`.
+- Optionally switches Clash Verge from TUN mode to macOS System Proxy.
+
+This is not socket-level transparent proxying. It only affects Antigravity processes started through this script.
+
+## Quick Start
+
+First make sure Clash Verge or Mihomo is running:
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+```
+
+For Clash Verge Rev, the script reads:
+
+- `~/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/clash-verge.yaml` for `mixed-port`
+- `~/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/verge.yaml` for `verge_mixed_port`
+
+Start Antigravity through the proxy launcher:
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+For `/Applications/Antigravity IDE.app`:
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor --app ide
+./scripts/macos-antigravity-proxy.sh restart --app ide
+```
+
+If the app does not quit cleanly:
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart --force-kill
+```
+
+## Use System Proxy Instead of TUN
+
+To update Clash Verge app settings:
+
+```bash
+./scripts/macos-antigravity-proxy.sh clash-verge use-system-proxy
+```
+
+This backs up and updates `verge.yaml`:
+
+- `enable_tun_mode: false`
+- `enable_system_proxy: true`
+- `enable_proxy_guard: true`
+
+If `/tmp/verge/verge-mihomo.sock` exists, the script also tries to disable runtime Mihomo TUN through the local controller API.
+
+To write the proxy into macOS network services:
+
+```bash
+./scripts/macos-antigravity-proxy.sh system-proxy on
+```
+
+To roll back macOS System Proxy:
+
+```bash
+./scripts/macos-antigravity-proxy.sh system-proxy off
+```
+
+## Custom Paths or Ports
+
+Use a custom proxy endpoint:
+
+```bash
+ANTIGRAVITY_PROXY_HOST=127.0.0.1 \
+ANTIGRAVITY_PROXY_PORT=7890 \
+./scripts/macos-antigravity-proxy.sh restart
+```
+
+Use a custom app path:
+
+```bash
+./scripts/macos-antigravity-proxy.sh restart --app "/path/to/Antigravity.app"
+```
+
+Environment variable alternatives:
+
+```bash
+ANTIGRAVITY_APP=ide ./scripts/macos-antigravity-proxy.sh restart
+ANTIGRAVITY_APP_PATH="/Applications/Antigravity IDE.app" ./scripts/macos-antigravity-proxy.sh restart
+```
+
+## Verify
+
+```bash
+./scripts/macos-antigravity-proxy.sh doctor
+./scripts/macos-antigravity-proxy.sh doctor --app ide
+```
+
+Expected signals:
+
+- `Detected proxy: 127.0.0.1:<port>`
+- `Proxy HTTP CONNECT test: ok`
+- the Antigravity process command line contains `--proxy-server=http://127.0.0.1:<port>`
+
+Logs are written to:
+
+```text
+~/Library/Logs/antigravity-proxy-macos/
+```
+
+## Notes
+
+- If Antigravity still reports `User location is not supported for the API use.`, the proxy may be working but the egress IP is rejected by the service.
+- Already-running Antigravity processes do not inherit new environment variables. Use `restart`.
+- Starting Antigravity directly from Finder or Dock bypasses this script unless you create a local launcher that calls it.

--- a/scripts/macos-antigravity-proxy.sh
+++ b/scripts/macos-antigravity-proxy.sh
@@ -1,0 +1,720 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLASH_DIR_DEFAULT="$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev"
+CLASH_CONFIG_DEFAULT="$CLASH_DIR_DEFAULT/clash-verge.yaml"
+VERGE_CONFIG_DEFAULT="$CLASH_DIR_DEFAULT/verge.yaml"
+LOG_DIR_DEFAULT="$HOME/Library/Logs/antigravity-proxy-macos"
+
+NO_PROXY_DEFAULT="localhost,127.0.0.1,::1,*.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+CHROMIUM_BYPASS_DEFAULT="<local>;localhost;127.0.0.1;::1;*.local;10.*;172.16.*;172.17.*;172.18.*;172.19.*;172.20.*;172.21.*;172.22.*;172.23.*;172.24.*;172.25.*;172.26.*;172.27.*;172.28.*;172.29.*;172.30.*;172.31.*;192.168.*"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/macos-antigravity-proxy.sh doctor [--app antigravity|ide|/path/App.app]
+  scripts/macos-antigravity-proxy.sh launch [--app antigravity|ide|/path/App.app] [-- extra-antigravity-args...]
+  scripts/macos-antigravity-proxy.sh restart [--app antigravity|ide|/path/App.app] [--force-kill] [-- extra-antigravity-args...]
+  scripts/macos-antigravity-proxy.sh env
+  scripts/macos-antigravity-proxy.sh system-proxy on|off|status
+  scripts/macos-antigravity-proxy.sh clash-verge use-system-proxy
+
+Environment overrides:
+  ANTIGRAVITY_APP            Default: antigravity. Use ide for /Applications/Antigravity IDE.app
+  ANTIGRAVITY_APP_PATH       Explicit app path. Overrides ANTIGRAVITY_APP.
+  ANTIGRAVITY_PROXY_HOST     Default: Clash Verge proxy_host or 127.0.0.1
+  ANTIGRAVITY_PROXY_PORT     Default: Clash Verge mixed-port/verge_mixed_port
+  ANTIGRAVITY_PROXY_SCHEME   Default: http
+  CLASH_VERGE_CONFIG         Default: ~/Library/Application Support/.../clash-verge.yaml
+  CLASH_VERGE_APP_CONFIG     Default: ~/Library/Application Support/.../verge.yaml
+  CLASH_VERGE_MIHOMO_SOCKET  Default: /tmp/verge/verge-mihomo.sock
+EOF
+}
+
+log() {
+  printf '[antigravity-proxy-macos] %s\n' "$*"
+}
+
+die() {
+  printf '[antigravity-proxy-macos] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+plist_value() {
+  local plist="$1"
+  local key="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2>/dev/null || true
+}
+
+yaml_value() {
+  local key="$1"
+  local file="$2"
+  [[ -f "$file" ]] || return 0
+  awk -F: -v key="$key" '
+    $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+      value=$0
+      sub(/^[^:]*:/, "", value)
+      sub(/[[:space:]]+#.*$/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^"|"$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+APP_SELECTOR="${ANTIGRAVITY_APP:-${ANTIGRAVITY_TARGET:-antigravity}}"
+PARSED_ARGS=()
+PARSED_FORCE_KILL=0
+
+parse_app_selector() {
+  local selector="$1"
+  case "$selector" in
+    ""|antigravity|ag|main|stable)
+      printf '%s\n' "antigravity"
+      ;;
+    ide|antigravity-ide|"Antigravity IDE")
+      printf '%s\n' "ide"
+      ;;
+    auto)
+      printf '%s\n' "auto"
+      ;;
+    /*|*.app)
+      printf '%s\n' "$selector"
+      ;;
+    *)
+      die "Unknown app selector: $selector (use antigravity, ide, auto, or /path/App.app)"
+      ;;
+  esac
+}
+
+parse_common_flags() {
+  PARSED_ARGS=()
+  while (($#)); do
+    case "$1" in
+      --app)
+        [[ -n "${2:-}" ]] || die "--app requires a value"
+        APP_SELECTOR="$(parse_app_selector "$2")"
+        shift 2
+        ;;
+      --app=*)
+        APP_SELECTOR="$(parse_app_selector "${1#--app=}")"
+        shift
+        ;;
+      --ide)
+        APP_SELECTOR="ide"
+        shift
+        ;;
+      --antigravity)
+        APP_SELECTOR="antigravity"
+        shift
+        ;;
+      --)
+        shift
+        PARSED_ARGS+=("$@")
+        break
+        ;;
+      *)
+        PARSED_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+parse_launch_flags() {
+  PARSED_ARGS=()
+  PARSED_FORCE_KILL=0
+  while (($#)); do
+    case "$1" in
+      --force-kill)
+        PARSED_FORCE_KILL=1
+        shift
+        ;;
+      --app)
+        [[ -n "${2:-}" ]] || die "--app requires a value"
+        APP_SELECTOR="$(parse_app_selector "$2")"
+        shift 2
+        ;;
+      --app=*)
+        APP_SELECTOR="$(parse_app_selector "${1#--app=}")"
+        shift
+        ;;
+      --ide)
+        APP_SELECTOR="ide"
+        shift
+        ;;
+      --antigravity)
+        APP_SELECTOR="antigravity"
+        shift
+        ;;
+      --)
+        shift
+        PARSED_ARGS+=("$@")
+        break
+        ;;
+      *)
+        PARSED_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+detect_app() {
+  if [[ -n "${ANTIGRAVITY_APP_PATH:-}" ]]; then
+    [[ -d "$ANTIGRAVITY_APP_PATH" ]] || die "ANTIGRAVITY_APP_PATH does not exist: $ANTIGRAVITY_APP_PATH"
+    printf '%s\n' "$ANTIGRAVITY_APP_PATH"
+    return
+  fi
+
+  local candidate
+  local selector
+  selector="$(parse_app_selector "$APP_SELECTOR")"
+
+  case "$selector" in
+    antigravity)
+      for candidate in "/Applications/Antigravity.app"; do
+        if [[ -d "$candidate" ]]; then
+          printf '%s\n' "$candidate"
+          return
+        fi
+      done
+      if command -v mdfind >/dev/null 2>&1; then
+        candidate="$(mdfind "kMDItemCFBundleIdentifier == 'com.google.antigravity'" | head -n 1 || true)"
+        if [[ -n "$candidate" && -d "$candidate" ]]; then
+          printf '%s\n' "$candidate"
+          return
+        fi
+      fi
+      ;;
+    ide)
+      for candidate in "/Applications/Antigravity IDE.app"; do
+        if [[ -d "$candidate" ]]; then
+          printf '%s\n' "$candidate"
+          return
+        fi
+      done
+      if command -v mdfind >/dev/null 2>&1; then
+        candidate="$(mdfind "kMDItemCFBundleIdentifier == 'com.google.antigravity-ide'" | head -n 1 || true)"
+        if [[ -n "$candidate" && -d "$candidate" ]]; then
+          printf '%s\n' "$candidate"
+          return
+        fi
+      fi
+      ;;
+    auto)
+      for candidate in "/Applications/Antigravity.app" "/Applications/Antigravity IDE.app"; do
+        if [[ -d "$candidate" ]]; then
+          printf '%s\n' "$candidate"
+          return
+        fi
+      done
+      ;;
+    /*|*.app)
+      [[ -d "$selector" ]] || die "App path does not exist: $selector"
+      printf '%s\n' "$selector"
+      return
+      ;;
+  esac
+
+  die "Cannot find app for selector '$selector'. Use --app /path/App.app or set ANTIGRAVITY_APP_PATH."
+}
+
+app_executable_path() {
+  local app="$1"
+  local plist="$app/Contents/Info.plist"
+  local executable
+  executable="$(plist_value "$plist" "CFBundleExecutable")"
+  [[ -n "$executable" ]] || die "Cannot read CFBundleExecutable from $plist"
+  printf '%s/Contents/MacOS/%s\n' "$app" "$executable"
+}
+
+app_bundle_id() {
+  local app="$1"
+  plist_value "$app/Contents/Info.plist" "CFBundleIdentifier"
+}
+
+detect_proxy_host() {
+  local verge_config="${CLASH_VERGE_APP_CONFIG:-$VERGE_CONFIG_DEFAULT}"
+  local host="${ANTIGRAVITY_PROXY_HOST:-}"
+  if [[ -z "$host" ]]; then
+    host="$(yaml_value "proxy_host" "$verge_config")"
+  fi
+  printf '%s\n' "${host:-127.0.0.1}"
+}
+
+port_is_open() {
+  local host="$1"
+  local port="$2"
+  nc -z -w 1 "$host" "$port" >/dev/null 2>&1
+}
+
+detect_proxy_port() {
+  local host="$1"
+  local clash_config="${CLASH_VERGE_CONFIG:-$CLASH_CONFIG_DEFAULT}"
+  local verge_config="${CLASH_VERGE_APP_CONFIG:-$VERGE_CONFIG_DEFAULT}"
+  local port="${ANTIGRAVITY_PROXY_PORT:-}"
+
+  if [[ -z "$port" ]]; then
+    port="$(yaml_value "mixed-port" "$clash_config")"
+  fi
+  if [[ -z "$port" ]]; then
+    port="$(yaml_value "verge_mixed_port" "$verge_config")"
+  fi
+  if [[ -n "$port" ]]; then
+    printf '%s\n' "$port"
+    return
+  fi
+
+  local candidate
+  for candidate in 7897 7890 7891 1080 10808; do
+    if port_is_open "$host" "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  die "Cannot detect Clash/Mihomo proxy port. Set ANTIGRAVITY_PROXY_PORT=7897"
+}
+
+proxy_scheme() {
+  printf '%s\n' "${ANTIGRAVITY_PROXY_SCHEME:-http}"
+}
+
+proxy_url() {
+  local host="$1"
+  local port="$2"
+  printf '%s://%s:%s\n' "$(proxy_scheme)" "$host" "$port"
+}
+
+app_slug() {
+  local app="$1"
+  basename "$app" .app |
+    tr '[:upper:]' '[:lower:]' |
+    tr -cs '[:alnum:]' '-' |
+    sed 's/^-//; s/-$//'
+}
+
+export_proxy_env() {
+  local host="$1"
+  local port="$2"
+  local http_url
+  http_url="http://$host:$port"
+
+  export HTTP_PROXY="$http_url"
+  export HTTPS_PROXY="$http_url"
+  export http_proxy="$http_url"
+  export https_proxy="$http_url"
+  export ALL_PROXY="socks5h://$host:$port"
+  export all_proxy="$ALL_PROXY"
+  export GRPC_PROXY="$http_url"
+  export GRPC_PROXY_EXP="$http_url"
+  export NO_PROXY="${ANTIGRAVITY_NO_PROXY:-$NO_PROXY_DEFAULT}"
+  export no_proxy="$NO_PROXY"
+}
+
+running_pids() {
+  local exec_path="$1"
+  ps -axo pid=,command= | awk -v path="$exec_path" '
+    {
+      command=$0
+      sub(/^[[:space:]]*[0-9]+[[:space:]]+/, "", command)
+    }
+    index(command, path) == 1 {
+      print $1
+    }
+  '
+}
+
+wait_for_exit() {
+  local exec_path="$1"
+  local i
+  for ((i = 0; i < 40; i++)); do
+    if [[ -z "$(running_pids "$exec_path")" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_for_start() {
+  local exec_path="$1"
+  local i
+  for ((i = 0; i < 40; i++)); do
+    if [[ -n "$(running_pids "$exec_path")" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+quit_app() {
+  local app="$1"
+  local exec_path="$2"
+  local bundle_id
+  bundle_id="$(app_bundle_id "$app")"
+  if [[ -n "$bundle_id" ]]; then
+    osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 || true
+  fi
+  wait_for_exit "$exec_path"
+}
+
+force_kill_app() {
+  local exec_path="$1"
+  local pid
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill "$pid" >/dev/null 2>&1 || true
+  done < <(running_pids "$exec_path")
+}
+
+test_proxy() {
+  local host="$1"
+  local port="$2"
+
+  port_is_open "$host" "$port" || die "Proxy port is not listening: $host:$port"
+  curl -fsS --max-time 8 -x "http://$host:$port" https://www.gstatic.com/generate_204 -o /dev/null
+}
+
+launch_app() {
+  local app="$1"
+  local exec_path="$2"
+  local host="$3"
+  local port="$4"
+  shift 4
+
+  test_proxy "$host" "$port"
+  export_proxy_env "$host" "$port"
+
+  local log_dir="${ANTIGRAVITY_PROXY_LOG_DIR:-$LOG_DIR_DEFAULT}"
+  mkdir -p "$log_dir"
+  local slug
+  slug="$(app_slug "$app")"
+  local log_file="$log_dir/$slug-$(date +%Y%m%d-%H%M%S).log"
+
+  local chrome_proxy
+  chrome_proxy="$(proxy_url "$host" "$port")"
+  local bypass="${ANTIGRAVITY_CHROMIUM_BYPASS:-$CHROMIUM_BYPASS_DEFAULT}"
+
+  log "Starting $app"
+  log "Proxy: $chrome_proxy"
+  log "Log: $log_file"
+
+  if (open --help 2>&1 || true) | grep -q -- '--env'; then
+    local stderr_file="${log_file%.log}.stderr.log"
+    open \
+      --stdout "$log_file" \
+      --stderr "$stderr_file" \
+      --env "HTTP_PROXY=$HTTP_PROXY" \
+      --env "HTTPS_PROXY=$HTTPS_PROXY" \
+      --env "http_proxy=$http_proxy" \
+      --env "https_proxy=$https_proxy" \
+      --env "ALL_PROXY=$ALL_PROXY" \
+      --env "all_proxy=$all_proxy" \
+      --env "GRPC_PROXY=$GRPC_PROXY" \
+      --env "GRPC_PROXY_EXP=$GRPC_PROXY_EXP" \
+      --env "NO_PROXY=$NO_PROXY" \
+      --env "no_proxy=$no_proxy" \
+      "$app" \
+      --args \
+      "--proxy-server=$chrome_proxy" \
+      "--proxy-bypass-list=$bypass" \
+      "$@"
+
+    if ! wait_for_start "$exec_path"; then
+      die "$app did not stay running. Check logs: $log_file $stderr_file"
+    fi
+    log "Started pid(s): $(running_pids "$exec_path" | tr '\n' ' ')"
+    return
+  fi
+
+  nohup "$exec_path" \
+    "--proxy-server=$chrome_proxy" \
+    "--proxy-bypass-list=$bypass" \
+    "$@" >>"$log_file" 2>&1 &
+
+  local pid=$!
+  sleep 1
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    die "$app process exited immediately. Check log: $log_file"
+  fi
+  log "Started pid=$pid"
+}
+
+print_env() {
+  local host
+  local port
+  host="$(detect_proxy_host)"
+  port="$(detect_proxy_port "$host")"
+  export_proxy_env "$host" "$port"
+
+  printf 'export HTTP_PROXY=%q\n' "$HTTP_PROXY"
+  printf 'export HTTPS_PROXY=%q\n' "$HTTPS_PROXY"
+  printf 'export ALL_PROXY=%q\n' "$ALL_PROXY"
+  printf 'export NO_PROXY=%q\n' "$NO_PROXY"
+  printf 'export GRPC_PROXY=%q\n' "$GRPC_PROXY"
+  printf 'export GRPC_PROXY_EXP=%q\n' "$GRPC_PROXY_EXP"
+}
+
+doctor() {
+  local app
+  local exec_path
+  local host
+  local port
+  app="$(detect_app)"
+  exec_path="$(app_executable_path "$app")"
+  host="$(detect_proxy_host)"
+  port="$(detect_proxy_port "$host")"
+
+  log "App selector: $(parse_app_selector "$APP_SELECTOR")"
+  log "App path: $app"
+  log "Executable: $exec_path"
+  log "Bundle id: $(app_bundle_id "$app")"
+  log "Clash config: ${CLASH_VERGE_CONFIG:-$CLASH_CONFIG_DEFAULT}"
+  log "Clash app config: ${CLASH_VERGE_APP_CONFIG:-$VERGE_CONFIG_DEFAULT}"
+  log "Detected proxy: $host:$port"
+
+  if port_is_open "$host" "$port"; then
+    log "Proxy port: open"
+  else
+    log "Proxy port: closed"
+  fi
+
+  if curl -fsS --max-time 8 -x "http://$host:$port" https://www.gstatic.com/generate_204 -o /dev/null; then
+    log "Proxy HTTP CONNECT test: ok"
+  else
+    log "Proxy HTTP CONNECT test: failed"
+  fi
+
+  local pids
+  local pids_csv
+  pids="$(running_pids "$exec_path")"
+  if [[ -n "$pids" ]]; then
+    pids_csv="$(printf '%s\n' "$pids" | paste -sd, -)"
+    log "Running app pid(s): $(printf '%s\n' "$pids" | tr '\n' ' ')"
+    ps -p "$pids_csv" -o pid=,command= | sed 's/^/[antigravity-proxy-macos] /'
+  else
+    log "Running app pid(s): none"
+  fi
+
+  log "System proxy summary:"
+  scutil --proxy | sed 's/^/[antigravity-proxy-macos] /'
+}
+
+network_services() {
+  networksetup -listallnetworkservices |
+    tail -n +2 |
+    sed 's/^\*//' |
+    awk 'length($0) > 0 { print }'
+}
+
+networksetup_or_warn() {
+  if ! networksetup "$@" >/dev/null 2>&1; then
+    log "Warning: networksetup $* failed"
+    return 1
+  fi
+  return 0
+}
+
+system_proxy_on() {
+  local host="$1"
+  local port="$2"
+  local bypass="${ANTIGRAVITY_SYSTEM_BYPASS:-localhost 127.0.0.1 ::1 *.local 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16}"
+  local service
+  while IFS= read -r service; do
+    log "Enable system proxy for: $service"
+    networksetup_or_warn -setwebproxy "$service" "$host" "$port" || true
+    networksetup_or_warn -setsecurewebproxy "$service" "$host" "$port" || true
+    networksetup_or_warn -setsocksfirewallproxy "$service" "$host" "$port" || true
+    networksetup_or_warn -setwebproxystate "$service" on || true
+    networksetup_or_warn -setsecurewebproxystate "$service" on || true
+    networksetup_or_warn -setsocksfirewallproxystate "$service" on || true
+    # shellcheck disable=SC2086
+    networksetup_or_warn -setproxybypassdomains "$service" $bypass || true
+  done < <(network_services)
+}
+
+system_proxy_off() {
+  local service
+  while IFS= read -r service; do
+    log "Disable system proxy for: $service"
+    networksetup_or_warn -setwebproxystate "$service" off || true
+    networksetup_or_warn -setsecurewebproxystate "$service" off || true
+    networksetup_or_warn -setsocksfirewallproxystate "$service" off || true
+  done < <(network_services)
+}
+
+set_top_yaml_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+
+  [[ -f "$file" ]] || die "Config file does not exist: $file"
+  if grep -Eq "^[[:space:]]*$key[[:space:]]*:" "$file"; then
+    perl -0pi -e "s/^([ \\t]*\\Q$key\\E[ \\t]*:).*$/\$1 $value/m" "$file"
+  else
+    printf '\n%s: %s\n' "$key" "$value" >>"$file"
+  fi
+}
+
+configure_clash_verge_system_proxy() {
+  local verge_config="${CLASH_VERGE_APP_CONFIG:-$VERGE_CONFIG_DEFAULT}"
+  [[ -f "$verge_config" ]] || die "Cannot find Clash Verge app config: $verge_config"
+
+  local backup="$verge_config.bak.$(date +%Y%m%d-%H%M%S)"
+  cp "$verge_config" "$backup"
+  set_top_yaml_value "$verge_config" "enable_tun_mode" "false"
+  set_top_yaml_value "$verge_config" "enable_system_proxy" "true"
+  set_top_yaml_value "$verge_config" "enable_proxy_guard" "true"
+  disable_generated_clash_tun
+  log "Updated Clash Verge app config: $verge_config"
+  log "Backup: $backup"
+  disable_mihomo_tun_runtime
+  log "If Clash Verge UI still shows the old state, restart Clash Verge or toggle System Proxy once."
+}
+
+disable_generated_clash_tun() {
+  local clash_config="${CLASH_VERGE_CONFIG:-$CLASH_CONFIG_DEFAULT}"
+  [[ -f "$clash_config" ]] || return 0
+
+  local backup="$clash_config.bak.$(date +%Y%m%d-%H%M%S)"
+  cp "$clash_config" "$backup"
+  if perl -0pi -e 'exit 2 unless s/(^tun:\n(?:[ \t]+[^\n]*\n)*?[ \t]+enable:)[ \t]*(?:true|false)/$1 false/m' "$clash_config"; then
+    log "Updated generated Clash config tun.enable=false: $clash_config"
+    log "Generated config backup: $backup"
+  else
+    log "Warning: failed to update generated Clash config tun.enable: $clash_config"
+  fi
+}
+
+mihomo_secret() {
+  local clash_config="${CLASH_VERGE_CONFIG:-$CLASH_CONFIG_DEFAULT}"
+  local secret
+  secret="$(yaml_value "secret" "$clash_config")"
+  printf '%s\n' "${secret:-set-your-secret}"
+}
+
+mihomo_socket() {
+  printf '%s\n' "${CLASH_VERGE_MIHOMO_SOCKET:-/tmp/verge/verge-mihomo.sock}"
+}
+
+disable_mihomo_tun_runtime() {
+  local socket
+  local secret
+  socket="$(mihomo_socket)"
+  secret="$(mihomo_secret)"
+
+  if [[ ! -S "$socket" ]]; then
+    log "Mihomo socket not found; runtime TUN will change after Clash Verge reloads config: $socket"
+    return 0
+  fi
+
+  if curl --unix-socket "$socket" -fsS --max-time 5 \
+      -X PATCH \
+      -H "Authorization: Bearer $secret" \
+      -H "Content-Type: application/json" \
+      --data '{"tun":{"enable":false}}' \
+      http://unix/configs >/dev/null; then
+    log "Disabled Mihomo runtime TUN via $socket"
+  else
+    log "Warning: failed to disable Mihomo runtime TUN via $socket"
+  fi
+}
+
+main() {
+  local command="${1:-}"
+  [[ -n "$command" ]] || { usage; exit 1; }
+  shift || true
+
+  case "$command" in
+    -h|--help|help)
+      usage
+      ;;
+    doctor)
+      parse_common_flags "$@"
+      doctor
+      ;;
+    env)
+      print_env
+      ;;
+    launch|restart)
+      parse_launch_flags "$@"
+
+      local app
+      local exec_path
+      local host
+      local port
+      app="$(detect_app)"
+      exec_path="$(app_executable_path "$app")"
+      host="$(detect_proxy_host)"
+      port="$(detect_proxy_port "$host")"
+
+      if [[ "$command" == "restart" ]]; then
+        if [[ -n "$(running_pids "$exec_path")" ]]; then
+          log "Quitting existing Antigravity instance..."
+          if ! quit_app "$app" "$exec_path"; then
+            if [[ "$PARSED_FORCE_KILL" == "1" ]]; then
+              log "Graceful quit timed out; force killing existing process."
+              force_kill_app "$exec_path"
+              wait_for_exit "$exec_path" || true
+            else
+              die "$app is still running. Re-run with: restart --app $(parse_app_selector "$APP_SELECTOR") --force-kill"
+            fi
+          fi
+        fi
+      elif [[ -n "$(running_pids "$exec_path")" ]]; then
+        die "$app is already running. Use 'restart --app $(parse_app_selector "$APP_SELECTOR")' so proxy env reaches child processes."
+      fi
+
+      if ((${#PARSED_ARGS[@]} > 0)); then
+        launch_app "$app" "$exec_path" "$host" "$port" "${PARSED_ARGS[@]}"
+      else
+        launch_app "$app" "$exec_path" "$host" "$port"
+      fi
+      ;;
+    system-proxy)
+      local action="${1:-}"
+      local host
+      local port
+      case "$action" in
+        on)
+          host="$(detect_proxy_host)"
+          port="$(detect_proxy_port "$host")"
+          test_proxy "$host" "$port"
+          system_proxy_on "$host" "$port"
+          scutil --proxy
+          ;;
+        off)
+          system_proxy_off
+          scutil --proxy
+          ;;
+        status)
+          scutil --proxy
+          ;;
+        *)
+          die "Usage: $0 system-proxy on|off|status"
+          ;;
+      esac
+      ;;
+    clash-verge)
+      local action="${1:-}"
+      case "$action" in
+        use-system-proxy)
+          configure_clash_verge_system_proxy
+          ;;
+        *)
+          die "Usage: $0 clash-verge use-system-proxy"
+          ;;
+      esac
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## 变更内容

- 新增 `scripts/macos-antigravity-proxy.sh`，为 macOS 提供 opt-in 代理启动器。
- 支持 `/Applications/Antigravity.app` 与 `/Applications/Antigravity IDE.app`。
- 自动检测 Clash Verge Rev / Mihomo mixed port，并通过 `--proxy-server` 与代理环境变量启动 Antigravity。
- 增加可选的 Clash Verge System Proxy/TUN 切换辅助命令。
- 新增中英文 macOS 使用文档，并在 README / README_EN 加入入口。

## 背景

Windows 版本依赖 `version.dll` 劫持与 MinHook/Winsock hook。macOS 下这条路径不能直接复用，尤其是签名 Electron app 和子进程会受到 SIP/hardened runtime 等限制。

这个 PR 采用不侵入 app bundle 的启动器方案：仅影响通过脚本启动的 Antigravity 进程和子进程，不改变 Windows DLL 构建路径。

## 验证

- `bash -n scripts/macos-antigravity-proxy.sh`
- `./scripts/macos-antigravity-proxy.sh env`
- `./scripts/macos-antigravity-proxy.sh doctor --app antigravity`
- `./scripts/macos-antigravity-proxy.sh doctor --app ide`

本机验证过 Clash Verge mixed port `127.0.0.1:7897` 可用，Antigravity / Antigravity IDE 主进程均带 `--proxy-server`，对应 `language_server` 子进程继承 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `GRPC_PROXY`。
