### PR TITLE
fix: scope Winsock/IOCP hooks to network subprocesses only (fix local TLS loopback breakage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ build-x64/
 build-x86/
 build-tests/
 build-process-name-tests/
+build-codex-x64/
+.codex-tools/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,15 @@ endif()
 add_library(version SHARED ${SOURCES_MINHOOK} ${SOURCES_HDE} ${SOURCES_PROXY} ${RESOURCES})
 
 # 设置模块定义文件 (导出 version.dll 函数)
-set_target_properties(version PROPERTIES
-  LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/src/proxy/version.def\""
-)
+if(MSVC)
+  set_target_properties(version PROPERTIES
+    LINK_FLAGS "/DEF:\"${CMAKE_CURRENT_SOURCE_DIR}/src/proxy/version.def\""
+  )
+else()
+  target_link_options(version PRIVATE
+    "-Wl,${CMAKE_CURRENT_SOURCE_DIR}/src/proxy/version.def"
+  )
+endif()
 
 target_include_directories(version PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
@@ -105,6 +111,10 @@ target_include_directories(version PRIVATE "src/hde/")
 
 # Link WS2_32 / WinHTTP
 target_link_libraries(version PRIVATE ws2_32 winhttp)
+
+if(NOT MSVC AND STATIC_RUNTIME)
+  target_link_options(version PRIVATE -static-libstdc++ -static-libgcc)
+endif()
 
 # Build Antigravity CLI shim (输出名为 dbghelp.dll)
 add_library(dbghelp SHARED

--- a/src/hooks/Hooks.cpp
+++ b/src/hooks/Hooks.cpp
@@ -4366,13 +4366,14 @@ int WSAAPI DetourWSASendTo(
 // ============= Hook 管理 =============
 
 namespace Hooks {
-    void Install() {
+    void Install(bool enableNetworkHooks) {
         if (MH_Initialize() != MH_OK) {
             Core::Logger::Error("MinHook 初始化失败");
             return;
         }
         
         // ===== Phase 1: 网络 Hooks =====
+        if (enableNetworkHooks) {
         
         // Hook connect
         if (MH_CreateHookApi(L"ws2_32.dll", "connect", 
@@ -4435,6 +4436,7 @@ namespace Hooks {
                              (LPVOID)DetourWSAGetOverlappedResult, (LPVOID*)&fpWSAGetOverlappedResult) != MH_OK) {
             Core::Logger::Error("Hook WSAGetOverlappedResult 失败");
         }
+        }
         
         // ===== Phase 2: 进程创建 Hook =====
         
@@ -4450,6 +4452,7 @@ namespace Hooks {
             Core::Logger::Error("Hook CreateProcessA 失败");
         }
         
+        if (enableNetworkHooks) {
         // Hook GetQueuedCompletionStatus (ConnectEx 完成握手)
         if (MH_CreateHookApi(L"kernel32.dll", "GetQueuedCompletionStatus",
                              (LPVOID)DetourGetQueuedCompletionStatus, (LPVOID*)&fpGetQueuedCompletionStatus) != MH_OK) {
@@ -4507,11 +4510,14 @@ namespace Hooks {
                              (LPVOID)DetourWSARecvFrom, (LPVOID*)&fpWSARecvFrom) != MH_OK) {
             Core::Logger::Error("Hook WSARecvFrom 失败");
         }
+        }
         
         if (MH_EnableHook(MH_ALL_HOOKS) != MH_OK) {
             Core::Logger::Error("启用 Hooks 失败");
         } else {
-            Core::Logger::Info("所有 API Hook 安装成功 (Phase 1-3)");
+            Core::Logger::Info(enableNetworkHooks
+                ? "所有 API Hook 安装成功 (Phase 1-3)"
+                : "注入器 Hook 安装成功 (仅 CreateProcessA/W，网络 Hook 已跳过)");
         }
     }
     

--- a/src/hooks/ProcessName.hpp
+++ b/src/hooks/ProcessName.hpp
@@ -84,4 +84,10 @@ inline bool IsLanguageServerProcessName(const std::string& processName) {
            lowerName.find("language_server_windows") != std::string::npos;
 }
 
+inline bool IsAntigravityHostProcessName(const std::string& processName) {
+    const std::string lowerName = ToLowerAsciiCopy(processName);
+    return lowerName == "antigravity.exe" ||
+           lowerName == "antigravity ide.exe";
+}
+
 } // namespace Hooks

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,12 @@
 #include <string>
 #include "core/Config.hpp"
 #include "core/Logger.hpp"
+#include "hooks/ProcessName.hpp"
 #include "update/UpdateChecker.hpp"
 
 // 前向声明
 namespace Hooks {
-    void Install();
+    void Install(bool enableNetworkHooks);
     void Uninstall();
 }
 
@@ -24,6 +25,13 @@ namespace VersionProxy {
 }
 
 namespace {
+    static std::string GetCurrentProcessBaseName() {
+        char processPath[MAX_PATH] = {0};
+        const DWORD len = GetModuleFileNameA(NULL, processPath, MAX_PATH);
+        if (len == 0 || len >= MAX_PATH) return "Unknown";
+        return Hooks::ExtractBaseNameFromPathLike(processPath);
+    }
+
     struct LoadNotifyPayload {
         bool success;
         bool askOpenLogs;
@@ -197,8 +205,15 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
             break;
         }
 
-        // 安装 Hooks（必须及时安装以确保网络流量被正确拦截）
-        Hooks::Install();
+        // Antigravity 的 Electron 网络服务子进程与主程序同名，也会通过 DLL 搜索顺序
+        // 自动加载本 DLL。它们只需保留 CreateProcess Hook 以继续注入 language server；
+        // 对这些进程安装 Winsock/IOCP Hook 会破坏 UI 与 language server 的本机自签名 TLS。
+        const std::string processName = GetCurrentProcessBaseName();
+        const bool enableNetworkHooks = !Hooks::IsAntigravityHostProcessName(processName);
+        if (!enableNetworkHooks) {
+            Core::Logger::Info("当前进程 " + processName + " 使用注入器模式：仅安装进程创建 Hook，跳过网络 Hook");
+        }
+        Hooks::Install(enableNetworkHooks);
         MaybeShowLoadNotifyAsync(true);
         // 更新检查默认关闭；启用后也只在后台异步提示，不阻塞 Hook 安装主流程。
         UpdateChecker::StartAsync();

--- a/tests/test_process_name.cpp
+++ b/tests/test_process_name.cpp
@@ -5,6 +5,7 @@
 
 int main() {
     using Hooks::GetCreateProcessTargetBaseNameA;
+    using Hooks::IsAntigravityHostProcessName;
     using Hooks::IsLanguageServerProcessName;
 
     // lpApplicationName 明确给出路径时，不按空格截断文件名。
@@ -32,6 +33,13 @@ int main() {
     assert(IsLanguageServerProcessName("language_server"));
     assert(IsLanguageServerProcessName("language_server_windows_x64.exe"));
     assert(!IsLanguageServerProcessName("Antigravity IDE.exe"));
+
+    // Electron 主程序及其同名子进程只负责继续注入，不安装网络 Hook，
+    // 避免破坏 UI 与 language server 之间的本机自签名 HTTPS/gRPC。
+    assert(IsAntigravityHostProcessName("Antigravity.exe"));
+    assert(IsAntigravityHostProcessName("ANTIGRAVITY IDE.EXE"));
+    assert(!IsAntigravityHostProcessName("language_server.exe"));
+    assert(!IsAntigravityHostProcessName("node.exe"));
 
     return 0;
 }


### PR DESCRIPTION
### Problem

`version.dll` is auto-loaded by the Antigravity main process and its
identically-named Electron child processes (DLL search order). The v2.2 proxy
installed full Winsock/IOCP hooks in **every** process, including the UI host
processes. This breaks the loopback HTTPS/gRPC connection between the UI and
the language server (self-signed cert), producing:

```
tls: unknown certificate
Lost connection to the language server. Agent features may not work.
```

The SOCKS5 tunnel itself succeeds (logs show `隧道建立成功`), but the app UI
cannot talk to the language server, so the proxy appears dead even though
traffic is being intercepted.

### Fix

Classify processes and scope hooks accordingly:

- `Antigravity.exe` / `Antigravity IDE.exe` (host processes): install
  **only** `CreateProcessA/W` hooks (needed to keep injecting child
  processes); skip network hooks entirely.
- `language_server.exe` / `node.exe` (network subprocesses): full network
  hooks → SOCKS5 proxy, so Google API traffic goes through the proxy while the
  UI↔language-server loopback stays untouched.

Changes:

- `src/hooks/ProcessName.hpp`: add `IsAntigravityHostProcessName()`
- `src/main.cpp`: pass process name / network-hook flag to `Hooks::Install()`,
  log injector mode
- `src/hooks/Hooks.cpp`: `Install(bool enableNetworkHooks)` — injector mode
  creates only CreateProcess hooks
- `tests/test_process_name.cpp`: classification tests for main process, IDE,
  language server, node
- `CMakeLists.txt`: LLVM-MinGW `.def` link compat + static CRT options
  (Windows x64 build chain)

### Verification

Built with LLVM-MinGW (clang x64, Release, tests ON):

- `antigravity_tests.exe` / `process_name_tests.exe`: pass
- Deployed DLL hash matches baseline, proxy log shows:
  - host process: `注入器模式`（injector mode, network hooks skipped）
  - language server: `所有 API Hook 安装成功 (Phase 1-3)`
  - `SOCKS5: 隧道建立成功` to `daily-cloudcode-pa.googleapis.com:443`
- language server log: `Auth succeeded`、`initialized server successfully`,
  no more `tls: unknown certificate` / `i/o timeout` errors

Verified live on Antigravity **v2.8.1** (2026-08-18).

### Notes for maintainer

The fix is additive and backwards compatible: non-Antigravity hosts (where
only one process loads the DLL and network hooks are always desired) behave
exactly as before, since `IsAntigravityHostProcessName()` only matches
`antigravity.exe` / `antigravity ide.exe`.

If the app renames its host processes in a future release, only
`IsAntigravityHostProcessName()` needs updating (see `target_processes` in
config.json for the current process names).